### PR TITLE
Fix toolbar arrow key navigation

### DIFF
--- a/SharpConsoleUI.Tests/FocusManagement/ToolbarFocusScopeTests.cs
+++ b/SharpConsoleUI.Tests/FocusManagement/ToolbarFocusScopeTests.cs
@@ -6,6 +6,7 @@
 // License: MIT
 // -----------------------------------------------------------------------
 
+using SharpConsoleUI.Builders;
 using SharpConsoleUI.Controls;
 using SharpConsoleUI.Tests.Infrastructure;
 using Xunit;
@@ -14,88 +15,400 @@ namespace SharpConsoleUI.Tests.FocusManagement;
 
 public class ToolbarFocusScopeTests
 {
-    [Fact]
-    public void GetNextFocus_AlwaysReturnsNull_TabExitsImmediately()
-    {
-        var system = TestWindowSystemBuilder.CreateTestSystem();
-        var window = new Window(system) { Width = 80, Height = 25 };
-        var toolbar = new ToolbarControl();
-        var item1 = new ButtonControl { Text = "File" };
-        var item2 = new ButtonControl { Text = "Edit" };
-        toolbar.AddItem(item1);
-        toolbar.AddItem(item2);
-        window.AddControl(toolbar);
+	#region Key helpers
 
-        var scope = (IFocusScope)toolbar;
-        Assert.Null(scope.GetNextFocus(item1, backward: false));
-        Assert.Null(scope.GetNextFocus(item2, backward: false));
-        Assert.Null(scope.GetNextFocus(item1, backward: true));
-    }
+	private static readonly ConsoleKeyInfo TabKey = new('\t', ConsoleKey.Tab, false, false, false);
+	private static readonly ConsoleKeyInfo ShiftTabKey = new('\t', ConsoleKey.Tab, true, false, false);
+	private static readonly ConsoleKeyInfo RightArrow = new('\0', ConsoleKey.RightArrow, false, false, false);
+	private static readonly ConsoleKeyInfo LeftArrow = new('\0', ConsoleKey.LeftArrow, false, false, false);
+	private static readonly ConsoleKeyInfo EnterKey = new('\r', ConsoleKey.Enter, false, false, false);
+	private static readonly ConsoleKeyInfo PageDownKey = new('\0', ConsoleKey.PageDown, false, false, false);
 
-    [Fact]
-    public void GetInitialFocus_ReturnsSavedFocus_WhenSet()
-    {
-        var system = TestWindowSystemBuilder.CreateTestSystem();
-        var window = new Window(system) { Width = 80, Height = 25 };
-        var toolbar = new ToolbarControl();
-        var item1 = new ButtonControl { Text = "File" };
-        var item2 = new ButtonControl { Text = "Edit" };
-        toolbar.AddItem(item1);
-        toolbar.AddItem(item2);
-        window.AddControl(toolbar);
+	private static void SendKey(Window window, ConsoleKeyInfo key)
+		=> window.EventDispatcher!.ProcessInput(key);
 
-        var scope = (IFocusScope)toolbar;
-        scope.SavedFocus = item2;
-        Assert.Equal(item2, scope.GetInitialFocus(backward: false));
-        Assert.Null(scope.SavedFocus); // consumed after one use
-    }
+	#endregion
 
-    [Fact]
-    public void GetInitialFocus_ReturnsFirstItem_WhenNoSavedFocus()
-    {
-        var system = TestWindowSystemBuilder.CreateTestSystem();
-        var window = new Window(system) { Width = 80, Height = 25 };
-        var toolbar = new ToolbarControl();
-        var item1 = new ButtonControl { Text = "File" };
-        toolbar.AddItem(item1);
-        window.AddControl(toolbar);
+	#region Setup helpers
 
-        var scope = (IFocusScope)toolbar;
-        Assert.Equal(item1, scope.GetInitialFocus(backward: false));
-    }
+	private static (ConsoleWindowSystem system, Window window) Setup()
+	{
+		var system = TestWindowSystemBuilder.CreateTestSystem(120, 40);
+		var window = new Window(system) { Width = 100, Height = 30 };
+		return (system, window);
+	}
 
-    [Fact]
-    public void GetInitialFocus_ReturnsLastItem_WhenBackwardAndNoSavedFocus()
-    {
-        var system = TestWindowSystemBuilder.CreateTestSystem();
-        var window = new Window(system) { Width = 80, Height = 25 };
-        var toolbar = new ToolbarControl();
-        var item1 = new ButtonControl { Text = "File" };
-        var item2 = new ButtonControl { Text = "Edit" };
-        toolbar.AddItem(item1);
-        toolbar.AddItem(item2);
-        window.AddControl(toolbar);
+	private static void Activate(ConsoleWindowSystem system, Window window)
+	{
+		system.AddWindow(window);
+		system.Render.UpdateDisplay();
+		system.Render.UpdateDisplay();
+	}
 
-        var scope = (IFocusScope)toolbar;
-        Assert.Equal(item2, scope.GetInitialFocus(backward: true));
-    }
+	#endregion
 
-    [Fact]
-    public void GetInitialFocus_ReturnsSavedFocus_IgnoresBackwardDirection()
-    {
-        var system = TestWindowSystemBuilder.CreateTestSystem();
-        var window = new Window(system) { Width = 80, Height = 25 };
-        var toolbar = new ToolbarControl();
-        var item1 = new ButtonControl { Text = "File" };
-        var item2 = new ButtonControl { Text = "Edit" };
-        toolbar.AddItem(item1);
-        toolbar.AddItem(item2);
-        window.AddControl(toolbar);
+	#region IFocusScope contract tests (original)
 
-        var scope = (IFocusScope)toolbar;
-        scope.SavedFocus = item2;
-        // Even with backward=true, SavedFocus is returned (direction doesn't matter when saved)
-        Assert.Equal(item2, scope.GetInitialFocus(backward: true));
-        Assert.Null(scope.SavedFocus); // consumed after one use
-    }
+	[Fact]
+	public void GetNextFocus_AlwaysReturnsNull_TabExitsImmediately()
+	{
+		var system = TestWindowSystemBuilder.CreateTestSystem();
+		var window = new Window(system) { Width = 80, Height = 25 };
+		var toolbar = new ToolbarControl();
+		var item1 = new ButtonControl { Text = "File" };
+		var item2 = new ButtonControl { Text = "Edit" };
+		toolbar.AddItem(item1);
+		toolbar.AddItem(item2);
+		window.AddControl(toolbar);
+
+		var scope = (IFocusScope)toolbar;
+		Assert.Null(scope.GetNextFocus(item1, backward: false));
+		Assert.Null(scope.GetNextFocus(item2, backward: false));
+		Assert.Null(scope.GetNextFocus(item1, backward: true));
+	}
+
+	[Fact]
+	public void GetInitialFocus_ReturnsSavedFocus_WhenSet()
+	{
+		var system = TestWindowSystemBuilder.CreateTestSystem();
+		var window = new Window(system) { Width = 80, Height = 25 };
+		var toolbar = new ToolbarControl();
+		var item1 = new ButtonControl { Text = "File" };
+		var item2 = new ButtonControl { Text = "Edit" };
+		toolbar.AddItem(item1);
+		toolbar.AddItem(item2);
+		window.AddControl(toolbar);
+
+		var scope = (IFocusScope)toolbar;
+		scope.SavedFocus = item2;
+		Assert.Equal(item2, scope.GetInitialFocus(backward: false));
+		Assert.Null(scope.SavedFocus); // consumed after one use
+	}
+
+	[Fact]
+	public void GetInitialFocus_ReturnsFirstItem_WhenNoSavedFocus()
+	{
+		var system = TestWindowSystemBuilder.CreateTestSystem();
+		var window = new Window(system) { Width = 80, Height = 25 };
+		var toolbar = new ToolbarControl();
+		var item1 = new ButtonControl { Text = "File" };
+		toolbar.AddItem(item1);
+		window.AddControl(toolbar);
+
+		var scope = (IFocusScope)toolbar;
+		Assert.Equal(item1, scope.GetInitialFocus(backward: false));
+	}
+
+	[Fact]
+	public void GetInitialFocus_ReturnsLastItem_WhenBackwardAndNoSavedFocus()
+	{
+		var system = TestWindowSystemBuilder.CreateTestSystem();
+		var window = new Window(system) { Width = 80, Height = 25 };
+		var toolbar = new ToolbarControl();
+		var item1 = new ButtonControl { Text = "File" };
+		var item2 = new ButtonControl { Text = "Edit" };
+		toolbar.AddItem(item1);
+		toolbar.AddItem(item2);
+		window.AddControl(toolbar);
+
+		var scope = (IFocusScope)toolbar;
+		Assert.Equal(item2, scope.GetInitialFocus(backward: true));
+	}
+
+	[Fact]
+	public void GetInitialFocus_ReturnsSavedFocus_IgnoresBackwardDirection()
+	{
+		var system = TestWindowSystemBuilder.CreateTestSystem();
+		var window = new Window(system) { Width = 80, Height = 25 };
+		var toolbar = new ToolbarControl();
+		var item1 = new ButtonControl { Text = "File" };
+		var item2 = new ButtonControl { Text = "Edit" };
+		toolbar.AddItem(item1);
+		toolbar.AddItem(item2);
+		window.AddControl(toolbar);
+
+		var scope = (IFocusScope)toolbar;
+		scope.SavedFocus = item2;
+		Assert.Equal(item2, scope.GetInitialFocus(backward: true));
+		Assert.Null(scope.SavedFocus);
+	}
+
+	#endregion
+
+	#region Arrow key navigation
+
+	[Fact]
+	public void ArrowRight_MovesFocusBetweenButtons()
+	{
+		var (system, window) = Setup();
+		var toolbar = new ToolbarControl();
+		var btn1 = new ButtonControl { Text = "File" };
+		var btn2 = new ButtonControl { Text = "Edit" };
+		toolbar.AddItem(btn1);
+		toolbar.AddItem(btn2);
+		window.AddControl(toolbar);
+		Activate(system, window);
+
+		// Focus first button via Tab into toolbar
+		window.FocusManager.SetFocus(btn1, FocusReason.Keyboard);
+		Assert.True(window.FocusManager.IsFocused(btn1));
+
+		SendKey(window, RightArrow);
+		Assert.True(window.FocusManager.IsFocused(btn2));
+	}
+
+	[Fact]
+	public void ArrowLeft_MovesFocusBackward()
+	{
+		var (system, window) = Setup();
+		var toolbar = new ToolbarControl();
+		var btn1 = new ButtonControl { Text = "File" };
+		var btn2 = new ButtonControl { Text = "Edit" };
+		toolbar.AddItem(btn1);
+		toolbar.AddItem(btn2);
+		window.AddControl(toolbar);
+		Activate(system, window);
+
+		window.FocusManager.SetFocus(btn2, FocusReason.Keyboard);
+
+		SendKey(window, LeftArrow);
+		Assert.True(window.FocusManager.IsFocused(btn1));
+	}
+
+	[Fact]
+	public void ArrowRight_AtLastButton_StaysOnLastButton()
+	{
+		var (system, window) = Setup();
+		var toolbar = new ToolbarControl();
+		var btn1 = new ButtonControl { Text = "File" };
+		var btn2 = new ButtonControl { Text = "Edit" };
+		toolbar.AddItem(btn1);
+		toolbar.AddItem(btn2);
+		window.AddControl(toolbar);
+		Activate(system, window);
+
+		window.FocusManager.SetFocus(btn2, FocusReason.Keyboard);
+
+		SendKey(window, RightArrow);
+		// NavigateFocus returns false at boundary, key falls through to window
+		// but focus should not have moved to btn1
+		Assert.False(window.FocusManager.IsFocused(btn1));
+	}
+
+	[Fact]
+	public void ArrowLeft_AtFirstButton_StaysOnFirstButton()
+	{
+		var (system, window) = Setup();
+		var toolbar = new ToolbarControl();
+		var btn1 = new ButtonControl { Text = "File" };
+		var btn2 = new ButtonControl { Text = "Edit" };
+		toolbar.AddItem(btn1);
+		toolbar.AddItem(btn2);
+		window.AddControl(toolbar);
+		Activate(system, window);
+
+		window.FocusManager.SetFocus(btn1, FocusReason.Keyboard);
+
+		SendKey(window, LeftArrow);
+		Assert.False(window.FocusManager.IsFocused(btn2));
+	}
+
+	#endregion
+
+	#region Tab entry/exit
+
+	[Fact]
+	public void Tab_EntersToolbar_FocusesFirstButton()
+	{
+		var (system, window) = Setup();
+		var beforeBtn = new ButtonControl { Text = "Before" };
+		var toolbar = new ToolbarControl();
+		var tbBtn1 = new ButtonControl { Text = "File" };
+		var tbBtn2 = new ButtonControl { Text = "Edit" };
+		toolbar.AddItem(tbBtn1);
+		toolbar.AddItem(tbBtn2);
+		window.AddControl(beforeBtn);
+		window.AddControl(toolbar);
+		Activate(system, window);
+
+		window.FocusManager.SetFocus(beforeBtn, FocusReason.Keyboard);
+
+		SendKey(window, TabKey);
+		Assert.True(window.FocusManager.IsFocused(tbBtn1));
+	}
+
+	[Fact]
+	public void ShiftTab_EntersToolbar_FocusesLastButton()
+	{
+		var (system, window) = Setup();
+		var toolbar = new ToolbarControl();
+		var tbBtn1 = new ButtonControl { Text = "File" };
+		var tbBtn2 = new ButtonControl { Text = "Edit" };
+		toolbar.AddItem(tbBtn1);
+		toolbar.AddItem(tbBtn2);
+		var afterBtn = new ButtonControl { Text = "After" };
+		window.AddControl(toolbar);
+		window.AddControl(afterBtn);
+		Activate(system, window);
+
+		window.FocusManager.SetFocus(afterBtn, FocusReason.Keyboard);
+
+		SendKey(window, ShiftTabKey);
+		Assert.True(window.FocusManager.IsFocused(tbBtn2));
+	}
+
+	[Fact]
+	public void Tab_ExitsToolbar_Forward()
+	{
+		var (system, window) = Setup();
+		var toolbar = new ToolbarControl();
+		var tbBtn1 = new ButtonControl { Text = "File" };
+		toolbar.AddItem(tbBtn1);
+		var afterBtn = new ButtonControl { Text = "After" };
+		window.AddControl(toolbar);
+		window.AddControl(afterBtn);
+		Activate(system, window);
+
+		window.FocusManager.SetFocus(tbBtn1, FocusReason.Keyboard);
+
+		SendKey(window, TabKey);
+		Assert.True(window.FocusManager.IsFocused(afterBtn));
+	}
+
+	[Fact]
+	public void ShiftTab_ExitsToolbar_Backward()
+	{
+		var (system, window) = Setup();
+		var beforeBtn = new ButtonControl { Text = "Before" };
+		var toolbar = new ToolbarControl();
+		var tbBtn1 = new ButtonControl { Text = "File" };
+		toolbar.AddItem(tbBtn1);
+		window.AddControl(beforeBtn);
+		window.AddControl(toolbar);
+		Activate(system, window);
+
+		window.FocusManager.SetFocus(tbBtn1, FocusReason.Keyboard);
+
+		SendKey(window, ShiftTabKey);
+		Assert.True(window.FocusManager.IsFocused(beforeBtn));
+	}
+
+	#endregion
+
+	#region Interaction
+
+	[Fact]
+	public void Enter_ActivatesButton()
+	{
+		var (system, window) = Setup();
+		var toolbar = new ToolbarControl();
+		var btn1 = new ButtonControl { Text = "File" };
+		bool clicked = false;
+		btn1.Click += (_, _) => clicked = true;
+		toolbar.AddItem(btn1);
+		window.AddControl(toolbar);
+		Activate(system, window);
+
+		window.FocusManager.SetFocus(btn1, FocusReason.Keyboard);
+
+		SendKey(window, EnterKey);
+		Assert.True(clicked);
+	}
+
+	[Fact]
+	public void HasFocus_True_WhenChildHasFocus()
+	{
+		var (system, window) = Setup();
+		var toolbar = new ToolbarControl();
+		var btn1 = new ButtonControl { Text = "File" };
+		toolbar.AddItem(btn1);
+		window.AddControl(toolbar);
+		Activate(system, window);
+
+		window.FocusManager.SetFocus(btn1, FocusReason.Keyboard);
+
+		Assert.True(toolbar.HasFocus);
+	}
+
+	#endregion
+
+	#region Mixed control types
+
+	[Fact]
+	public void PromptControl_KeepsArrowKeys_ToolbarDoesNotNavigate()
+	{
+		var (system, window) = Setup();
+		var toolbar = new ToolbarControl();
+		var prompt = new PromptControl { Prompt = "> ", InputWidth = 20 };
+		var btn2 = new ButtonControl { Text = "OK" };
+		toolbar.AddItem(prompt);
+		toolbar.AddItem(btn2);
+		window.AddControl(toolbar);
+		Activate(system, window);
+
+		// Type some text into the prompt so RightArrow has room to move cursor
+		window.FocusManager.SetFocus(prompt, FocusReason.Keyboard);
+		// Type 'h'
+		SendKey(window, new ConsoleKeyInfo('h', ConsoleKey.H, false, false, false));
+
+		// Now cursor is at pos 1. Send LeftArrow — PromptControl should consume it
+		SendKey(window, LeftArrow);
+
+		// Focus should still be on prompt, not navigated to btn2
+		Assert.True(window.FocusManager.IsFocused(prompt));
+		Assert.False(window.FocusManager.IsFocused(btn2));
+	}
+
+	[Fact]
+	public void CheckboxControl_ArrowsNavigateToolbar()
+	{
+		var (system, window) = Setup();
+		var toolbar = new ToolbarControl();
+		var checkbox = new CheckboxControl { Label = "Option" };
+		var btn2 = new ButtonControl { Text = "OK" };
+		toolbar.AddItem(checkbox);
+		toolbar.AddItem(btn2);
+		window.AddControl(toolbar);
+		Activate(system, window);
+
+		window.FocusManager.SetFocus(checkbox, FocusReason.Keyboard);
+
+		SendKey(window, RightArrow);
+		Assert.True(window.FocusManager.IsFocused(btn2));
+	}
+
+	#endregion
+
+	#region Key bubbling
+
+	[Fact]
+	public void KeyBubbles_FromButton_ToToolbar()
+	{
+		// The arrow key navigation tests already prove bubbling works
+		// (dispatcher sends arrow to button → button returns false → bubbles to toolbar → toolbar navigates).
+		// This test explicitly verifies the mechanism: a button inside a toolbar
+		// that doesn't handle RightArrow causes the toolbar to navigate.
+		var (system, window) = Setup();
+		var toolbar = new ToolbarControl();
+		var btn1 = new ButtonControl { Text = "A" };
+		var btn2 = new ButtonControl { Text = "B" };
+		toolbar.AddItem(btn1);
+		toolbar.AddItem(btn2);
+		window.AddControl(toolbar);
+		Activate(system, window);
+
+		window.FocusManager.SetFocus(btn1, FocusReason.Keyboard);
+
+		// RightArrow: button doesn't handle it → bubbles to toolbar → toolbar navigates
+		SendKey(window, RightArrow);
+		Assert.True(window.FocusManager.IsFocused(btn2),
+			"Expected RightArrow to bubble from button to toolbar and navigate to btn2");
+
+		// Navigate back
+		SendKey(window, LeftArrow);
+		Assert.True(window.FocusManager.IsFocused(btn1),
+			"Expected LeftArrow to bubble from button to toolbar and navigate to btn1");
+	}
+
+	#endregion
 }

--- a/SharpConsoleUI/Controls/ToolbarControl.cs
+++ b/SharpConsoleUI/Controls/ToolbarControl.cs
@@ -117,7 +117,7 @@ namespace SharpConsoleUI.Controls
 		/// <inheritdoc/>
 		public bool HasFocus
 		{
-			get => ComputeHasFocus();
+			get => ComputeIsInFocusPath();
 		}
 
 		/// <summary>
@@ -374,35 +374,28 @@ namespace SharpConsoleUI.Controls
 		/// <inheritdoc/>
 		public bool ProcessKey(ConsoleKeyInfo key)
 		{
-			if (!_isEnabled || !(ComputeHasFocus()))
+			if (!_isEnabled || !ComputeIsInFocusPath())
 				return false;
 
-			// First, let focused item handle the key (Enter, Space, etc.)
+			// Sync _focusedItem with FocusManager state.
+			// When focus is set externally (e.g., Tab into toolbar via IFocusScope),
+			// _focusedItem may be stale. Align it with the actual focused control.
+			SyncFocusedItemFromFocusManager();
+
+			// Let focused item handle the key first (Enter/Space for buttons,
+			// arrows for PromptControl cursor movement, etc.)
 			if (_focusedItem != null && _focusedItem.ProcessKey(key))
 				return true;
 
-			// Then handle toolbar-level navigation (Tab)
-			if (key.Key == ConsoleKey.Tab)
-			{
-				bool backward = key.Modifiers.HasFlag(ConsoleModifiers.Shift);
-				return NavigateFocus(backward);
-			}
-
-			// Arrow keys for navigation within toolbar
+			// Arrow keys: navigate between toolbar items
 			if (key.Key == ConsoleKey.LeftArrow)
-			{
 				return NavigateFocus(backward: true);
-			}
 			if (key.Key == ConsoleKey.RightArrow)
-			{
 				return NavigateFocus(backward: false);
-			}
 
 			// Up/Down arrow navigation between rows (only when wrapping)
 			if (_wrap && (key.Key == ConsoleKey.UpArrow || key.Key == ConsoleKey.DownArrow))
-			{
 				return NavigateFocusVertical(key.Key == ConsoleKey.UpArrow);
-			}
 
 			return false;
 		}
@@ -990,6 +983,35 @@ namespace SharpConsoleUI.Controls
 
 			Container?.Invalidate(true);
 			return true;
+		}
+
+		/// <summary>
+		/// Synchronizes _focusedItem with the FocusManager's actual focused control.
+		/// Called at the start of ProcessKey to handle external focus changes
+		/// (e.g., Tab entry via IFocusScope.GetInitialFocus).
+		/// </summary>
+		private void SyncFocusedItemFromFocusManager()
+		{
+			var window = this.GetParentWindow();
+			if (window == null) return;
+
+			var fmFocused = window.FocusManager.FocusedControl;
+			if (fmFocused == null) return;
+
+			// Check if the FocusManager's focused control is one of our items
+			if (fmFocused is IInteractiveControl interactive)
+			{
+				List<IWindowControl> snapshot;
+				lock (_toolbarLock) { snapshot = _items.ToList(); }
+				foreach (var item in snapshot)
+				{
+					if (item == fmFocused)
+					{
+						_focusedItem = interactive;
+						return;
+					}
+				}
+			}
 		}
 
 		private void SetItemFocus(IInteractiveControl item, bool focus)

--- a/SharpConsoleUI/Windows/WindowEventDispatcher.cs
+++ b/SharpConsoleUI/Windows/WindowEventDispatcher.cs
@@ -508,6 +508,19 @@ namespace SharpConsoleUI.Windows
 					}
 
 					contentKeyHandled = activeInteractiveContent!.ProcessKey(key);
+
+					// Bubble unhandled keys up the visual tree to ancestor containers.
+					// Standard UI framework behavior: events propagate from leaf to root.
+					if (!contentKeyHandled && activeInteractiveContent is IWindowControl leafWc)
+					{
+						IWindowControl? ancestor = Core.FocusManager.ResolveParentWindowControl(leafWc);
+						while (ancestor != null && !contentKeyHandled)
+						{
+							if (ancestor is Controls.IInteractiveControl parentIc && parentIc.IsEnabled)
+								contentKeyHandled = parentIc.ProcessKey(key);
+							ancestor = Core.FocusManager.ResolveParentWindowControl(ancestor);
+						}
+					}
 				}
 				else
 				{


### PR DESCRIPTION
## Summary

Fixes #4 — Arrow keys now correctly navigate between toolbar buttons.

**Two independent bugs prevented this:**
- `ToolbarControl.HasFocus` used leaf semantics (`ComputeHasFocus`), returning false when a child button had focus — causing `ProcessKey` to bail early
- `WindowEventDispatcher` had no key bubbling — unhandled keys from the leaf control were lost instead of propagating to parent containers

**Changes:**
- `ToolbarControl`: Switch to `ComputeIsInFocusPath()`, remove redundant Tab handling, add `SyncFocusedItemFromFocusManager()` for external focus changes
- `WindowEventDispatcher`: Bubble unhandled keys up the visual tree via `ResolveParentWindowControl`
- 18 tests covering arrow navigation, Tab entry/exit, Enter activation, mixed control types, and key bubbling

## Test plan

- [x] All 2506 tests pass (0 failures)
- [x] Arrow Right/Left moves focus between toolbar buttons
- [x] Tab enters/exits toolbar correctly (via IFocusScope)
- [x] Enter activates focused button
- [x] PromptControl keeps arrow keys for cursor movement
- [x] CheckboxControl arrows navigate toolbar
- [x] No regressions in LazyNuGetFocusTests, TabControlFocusTests, WantsTabKeyTests