### PR TITLE
Fix click-to-focus scroll jump in ScrollablePanelControl

### DIFF
--- a/SharpConsoleUI.Tests/FocusManagement/ClickFocusScrollTests.cs
+++ b/SharpConsoleUI.Tests/FocusManagement/ClickFocusScrollTests.cs
@@ -1,0 +1,273 @@
+// -----------------------------------------------------------------------
+// ConsoleEx - A simple console window system for .NET Core
+//
+// Author: Nikolaos Protopapas
+// Email: nikolaos.protopapas@gmail.com
+// License: MIT
+// -----------------------------------------------------------------------
+
+using SharpConsoleUI;
+using SharpConsoleUI.Controls;
+using SharpConsoleUI.Core;
+using SharpConsoleUI.Layout;
+using SharpConsoleUI.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpConsoleUI.Tests.FocusManagement;
+
+/// <summary>
+/// Tests that clicking to focus a child inside a ScrollablePanelControl
+/// does not cause a scroll jump. Verifies the fix for IFocusScope delegation
+/// and ScrollChildIntoView being skipped for Mouse reason.
+/// </summary>
+public class ClickFocusScrollTests
+{
+	/// <summary>
+	/// Builds a scrolled-down SPC with two buttons (one at top, one at bottom).
+	/// Returns the system pre-scrolled so button2 is visible and button1 is off-screen above.
+	/// </summary>
+	private static (ConsoleWindowSystem system, Window window,
+		ScrollablePanelControl panel, ButtonControl button1, ButtonControl button2)
+		BuildScrolledPanel()
+	{
+		var panel = new ScrollablePanelControl
+		{
+			VerticalAlignment = VerticalAlignment.Fill,
+			AutoScroll = false
+		};
+
+		var button1 = new ButtonControl { Text = "Top Button" };
+		panel.AddControl(button1);
+
+		// Tall filler content to force scrolling
+		var lines = new List<string>();
+		for (int i = 0; i < 50; i++)
+			lines.Add($"Line {i}");
+		panel.AddControl(new MarkupControl(lines));
+
+		var button2 = new ButtonControl { Text = "Bottom Button" };
+		panel.AddControl(button2);
+
+		var system = TestWindowSystemBuilder.CreateTestSystem(80, 20);
+		var window = new Window(system)
+		{
+			Title = "Test", Left = 0, Top = 0, Width = 80, Height = 20
+		};
+		window.AddControl(panel);
+		system.AddWindow(window);
+		system.Render.UpdateDisplay();
+		system.Render.UpdateDisplay();
+
+		return (system, window, panel, button1, button2);
+	}
+
+	#region Step 1: IFocusScope delegation skipped for Mouse
+
+	/// <summary>
+	/// SetFocus(spc, Mouse) should focus SPC itself, NOT delegate to first child.
+	/// This is the core fix: mouse clicks let ProcessMouseEvent handle child targeting.
+	/// </summary>
+	[Fact]
+	public void SetFocus_Mouse_OnSPC_DoesNotDelegateToFirstChild()
+	{
+		var (system, window, panel, button1, button2) = BuildScrolledPanel();
+
+		// Clear any auto-focus
+		window.FocusManager.SetFocus(null, FocusReason.Programmatic);
+
+		// Focus SPC with Mouse reason — should NOT delegate to first child
+		window.FocusManager.SetFocus(panel, FocusReason.Mouse);
+
+		Assert.True(window.FocusManager.IsFocused(panel),
+			"SetFocus(SPC, Mouse) should focus the SPC directly");
+		Assert.False(window.FocusManager.IsFocused(button1),
+			"SetFocus(SPC, Mouse) should NOT delegate to first child button");
+	}
+
+	/// <summary>
+	/// SetFocus(spc, Keyboard) should delegate to first child (existing behavior preserved).
+	/// </summary>
+	[Fact]
+	public void SetFocus_Keyboard_OnSPC_DelegatesToFirstChild()
+	{
+		var (system, window, panel, button1, button2) = BuildScrolledPanel();
+
+		// Clear any auto-focus
+		window.FocusManager.SetFocus(null, FocusReason.Programmatic);
+
+		// Focus SPC with Keyboard reason — should delegate to first child
+		window.FocusManager.SetFocus(panel, FocusReason.Keyboard);
+
+		Assert.True(window.FocusManager.IsFocused(button1),
+			"SetFocus(SPC, Keyboard) should delegate to first focusable child");
+	}
+
+	#endregion
+
+	#region Step 2: ScrollChildIntoView skipped for Mouse
+
+	/// <summary>
+	/// When focusing via Mouse, scroll offset should not change.
+	/// The clicked control is already visible — no scroll needed.
+	/// </summary>
+	[Fact]
+	public void SetFocus_Mouse_SkipsScrollChildIntoView()
+	{
+		var (system, window, panel, button1, button2) = BuildScrolledPanel();
+
+		// Scroll down so button2 is visible
+		panel.ScrollVerticalBy(40);
+		system.Render.UpdateDisplay();
+		int scrollBefore = panel.VerticalScrollOffset;
+
+		// Focus button2 via Mouse — should NOT trigger ScrollChildIntoView
+		window.FocusManager.SetFocus(button2, FocusReason.Mouse);
+
+		Assert.Equal(scrollBefore, panel.VerticalScrollOffset);
+	}
+
+	/// <summary>
+	/// When focusing via Keyboard, ScrollChildIntoView should adjust scroll offset
+	/// (existing behavior preserved).
+	/// </summary>
+	[Fact]
+	public void SetFocus_Keyboard_ScrollsChildIntoView()
+	{
+		var (system, window, panel, button1, button2) = BuildScrolledPanel();
+
+		// Ensure we're at top
+		panel.ScrollToTop();
+		system.Render.UpdateDisplay();
+
+		// Clear focus first
+		window.FocusManager.SetFocus(null, FocusReason.Programmatic);
+
+		// Focus button2 via Keyboard — button2 is off-screen, should scroll
+		window.FocusManager.SetFocus(button2, FocusReason.Keyboard);
+
+		Assert.True(panel.VerticalScrollOffset > 0,
+			$"Keyboard focus on off-screen button should trigger scroll. Offset: {panel.VerticalScrollOffset}");
+	}
+
+	#endregion
+
+	#region HandleClick integration
+
+	/// <summary>
+	/// HandleClick on a focusable child inside SPC should focus the child directly,
+	/// not the SPC (which would then delegate to the wrong child).
+	/// </summary>
+	[Fact]
+	public void HandleClick_OnFocusableChild_FocusesDirectly()
+	{
+		var (system, window, panel, button1, button2) = BuildScrolledPanel();
+
+		// Scroll down so button2 is visible
+		panel.ScrollVerticalBy(40);
+		system.Render.UpdateDisplay();
+		int scrollBefore = panel.VerticalScrollOffset;
+
+		// Simulate HandleClick on button2
+		window.FocusManager.HandleClick(button2);
+
+		Assert.True(window.FocusManager.IsFocused(button2),
+			"HandleClick on button should focus the button directly");
+		Assert.Equal(scrollBefore, panel.VerticalScrollOffset);
+	}
+
+	/// <summary>
+	/// HandleClick on a non-focusable control (e.g. MarkupControl) walks up to
+	/// the nearest focusable ancestor (SPC). With the fix, SetFocus(SPC, Mouse)
+	/// focuses SPC directly without delegating to first child — no scroll jump.
+	/// </summary>
+	[Fact]
+	public void HandleClick_OnNonFocusable_FocusesSPC()
+	{
+		var panel = new ScrollablePanelControl
+		{
+			VerticalAlignment = VerticalAlignment.Fill,
+			AutoScroll = false
+		};
+
+		var markup = new MarkupControl(new List<string> { "Some text content" });
+		panel.AddControl(markup);
+
+		var button = new ButtonControl { Text = "Button" };
+		panel.AddControl(button);
+
+		var system = TestWindowSystemBuilder.CreateTestSystem(80, 20);
+		var window = new Window(system)
+		{
+			Title = "Test", Left = 0, Top = 0, Width = 80, Height = 20
+		};
+		window.AddControl(panel);
+		system.AddWindow(window);
+		system.Render.UpdateDisplay();
+		system.Render.UpdateDisplay();
+
+		// Clear auto-focus
+		window.FocusManager.SetFocus(null, FocusReason.Programmatic);
+
+		// HandleClick on non-focusable MarkupControl — walks up to SPC
+		window.FocusManager.HandleClick(markup);
+
+		// SPC should be focused directly (not button via GetInitialFocus delegation)
+		Assert.True(window.FocusManager.IsFocused(panel),
+			"HandleClick on non-focusable child should focus the SPC directly (Mouse reason)");
+		Assert.False(window.FocusManager.IsFocused(button),
+			"HandleClick should NOT delegate to first child via GetInitialFocus");
+	}
+
+	#endregion
+
+	#region Step 4: Tab after mouse click enters normally
+
+	/// <summary>
+	/// After a mouse click on SPC empty space (which focuses SPC directly),
+	/// Tab should enter SPC's first child normally — NOT enter scroll mode.
+	/// This verifies the _enterScrollModeOnNextInitialFocus flag removal.
+	/// </summary>
+	[Fact]
+	public void Tab_AfterMouseClick_EntersNormally()
+	{
+		var panel = new ScrollablePanelControl
+		{
+			VerticalAlignment = VerticalAlignment.Fill,
+			AutoScroll = false
+		};
+
+		var button1 = new ButtonControl { Text = "First" };
+		panel.AddControl(button1);
+
+		var button2 = new ButtonControl { Text = "Second" };
+		panel.AddControl(button2);
+
+		var system = TestWindowSystemBuilder.CreateTestSystem(80, 20);
+		var window = new Window(system)
+		{
+			Title = "Test", Left = 0, Top = 0, Width = 80, Height = 20
+		};
+		window.AddControl(panel);
+		system.AddWindow(window);
+		system.Render.UpdateDisplay();
+		system.Render.UpdateDisplay();
+
+		// Simulate: SetFocus(SPC, Mouse) — as if user clicked empty space
+		window.FocusManager.SetFocus(panel, FocusReason.Mouse);
+		Assert.True(window.FocusManager.IsFocused(panel),
+			"SPC should be directly focused after mouse click");
+
+		// Now Tab — should enter SPC normally and focus first child
+		var tabKey = new ConsoleKeyInfo('\t', ConsoleKey.Tab, false, false, false);
+		window.SwitchFocus(backward: false);
+
+		// After Tab from SPC, focus should move to first child (button1)
+		// or at least not stay on SPC in scroll mode
+		var focused = window.FocusManager.FocusedControl;
+		Assert.True(
+			window.FocusManager.IsFocused(button1) || window.FocusManager.IsFocused(button2),
+			$"Tab after mouse-focused SPC should enter a child. Focused: {focused?.GetType().Name ?? "null"}");
+	}
+
+	#endregion
+}

--- a/SharpConsoleUI/Controls/ScrollablePanelControl/ScrollablePanelControl.Mouse.cs
+++ b/SharpConsoleUI/Controls/ScrollablePanelControl/ScrollablePanelControl.Mouse.cs
@@ -377,7 +377,6 @@ namespace SharpConsoleUI.Controls
 						var emptyClickWindow = (this as IWindowControl).GetParentWindow();
 						if (emptyClickWindow != null && CanReceiveFocus)
 						{
-							_enterScrollModeOnNextInitialFocus = true;
 							emptyClickWindow.FocusManager.SetFocus(this, FocusReason.Mouse);
 						}
 						_lastInternalFocusedChild = null;

--- a/SharpConsoleUI/Core/FocusManager.cs
+++ b/SharpConsoleUI/Core/FocusManager.cs
@@ -48,13 +48,14 @@ public class FocusManager
         // Transparent scopes (CanReceiveFocus=false, e.g. HGrid) are NOT entered here —
         // they are handled by the CanReceiveFocus guard below, which rejects them.
         // HGrid children are reached via MoveFocus/BuildFlatList traversal instead.
-        if (control is IFocusScope scope && control.CanReceiveFocus)
+        if (reason != FocusReason.Mouse
+            && control is IFocusScope scope && control.CanReceiveFocus)
         {
             var backward = false;
             var child = scope.GetInitialFocus(backward);
             if (child != null && !ReferenceEquals(child, control))
             {
-                EnterOrFocus(child, backward);
+                EnterOrFocus(child, backward, reason);
                 return;
             }
             // child == null, or child == control (self-sentinel) → fall through to focus scope itself
@@ -75,7 +76,7 @@ public class FocusManager
         // Scroll any IScrollableContainer ancestor to show the newly focused control.
         // Walk the focus path from the focused control upward; for each scrollable container,
         // scroll its direct child in the path into view.
-        if (control is IWindowControl focusedWc)
+        if (reason != FocusReason.Mouse && control is IWindowControl focusedWc)
         {
             var path = FocusPath;
             for (int i = path.Count - 1; i >= 1; i--)
@@ -182,18 +183,18 @@ public class FocusManager
         }
     }
 
-    private void EnterOrFocus(IFocusableControl target, bool backward)
+    private void EnterOrFocus(IFocusableControl target, bool backward, FocusReason reason = FocusReason.Keyboard)
     {
         if (target is IFocusScope scope)
         {
             var child = scope.GetInitialFocus(backward);
             if (child != null && !ReferenceEquals(child, target))
             {
-                EnterOrFocus(child, backward);
+                EnterOrFocus(child, backward, reason);
                 return;
             }
         }
-        SetFocus(target, FocusReason.Keyboard);
+        SetFocus(target, reason);
     }
 
     // NOTE: FindInnermostScope starts at control.Container (not the control itself).


### PR DESCRIPTION
## Summary

- Skip `IFocusScope` delegation and `ScrollChildIntoView` in `FocusManager.SetFocus` when reason is `Mouse` — mouse-clicked controls are already visible, and `ProcessMouseEvent` handles child targeting correctly
- Propagate `FocusReason` through `EnterOrFocus` (private, defaulted parameter — backward-compatible)
- Remove stale `_enterScrollModeOnNextInitialFocus` flag set on mouse empty-space clicks in SPC

Fixes #8

## Test plan

- [x] 7 new tests in `ClickFocusScrollTests.cs` covering all fix aspects
- [x] 70 focus regression tests pass (LazyNuGetFocus, FocusEdgeCase, FocusRegression, ScrollToFocusedChild, ScrollablePanelFocusScope, ToolbarFocusScope, NavigationViewFocusScope)
- [x] Full suite: 2534/2534 passing