### PR TITLE
fix: delegate Container overrides to base so SubscribeToFocusManager runs

### DIFF
--- a/SharpConsoleUI.Tests/FocusManagement/ContainerFocusSubscriptionTests.cs
+++ b/SharpConsoleUI.Tests/FocusManagement/ContainerFocusSubscriptionTests.cs
@@ -1,0 +1,156 @@
+// -----------------------------------------------------------------------
+// ConsoleEx - A simple console window system for .NET Core
+//
+// Author: Nikolaos Protopapas
+// Email: nikolaos.protopapas@gmail.com
+// License: MIT
+// -----------------------------------------------------------------------
+
+using SharpConsoleUI.Controls;
+using SharpConsoleUI.Core;
+using SharpConsoleUI.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpConsoleUI.Tests.FocusManagement;
+
+/// <summary>
+/// Verifies that controls which override Container properly delegate to
+/// base.Container, ensuring SubscribeToFocusManager() runs and
+/// GotFocus/LostFocus events fire.
+/// </summary>
+public class ContainerFocusSubscriptionTests
+{
+    [Fact]
+    public void MultilineEditControl_GotFocus_Fires_WhenFocused()
+    {
+        var system = TestWindowSystemBuilder.CreateTestSystem();
+        var window = new Window(system) { Width = 80, Height = 25 };
+        // Add a placeholder first so it gets auto-focus, not the edit control
+        var placeholder = new ButtonControl { Text = "Placeholder" };
+        window.AddControl(placeholder);
+
+        var edit = new MultilineEditControl();
+        window.AddControl(edit);
+
+        bool gotFocusFired = false;
+        edit.GotFocus += (_, _) => gotFocusFired = true;
+
+        window.FocusManager.SetFocus(edit, FocusReason.Programmatic);
+
+        Assert.True(gotFocusFired, "GotFocus should fire for MultilineEditControl after Container fix");
+    }
+
+    [Fact]
+    public void MultilineEditControl_LostFocus_Fires_WhenUnfocused()
+    {
+        var system = TestWindowSystemBuilder.CreateTestSystem();
+        var window = new Window(system) { Width = 80, Height = 25 };
+        var placeholder = new ButtonControl { Text = "Placeholder" };
+        window.AddControl(placeholder);
+
+        var edit = new MultilineEditControl();
+        window.AddControl(edit);
+
+        window.FocusManager.SetFocus(edit, FocusReason.Programmatic);
+
+        bool lostFocusFired = false;
+        edit.LostFocus += (_, _) => lostFocusFired = true;
+
+        window.FocusManager.SetFocus(placeholder, FocusReason.Programmatic);
+
+        Assert.True(lostFocusFired, "LostFocus should fire for MultilineEditControl after Container fix");
+    }
+
+    [Fact]
+    public void SliderControl_GotFocus_Fires_WhenFocused()
+    {
+        var system = TestWindowSystemBuilder.CreateTestSystem();
+        var window = new Window(system) { Width = 80, Height = 25 };
+        var placeholder = new ButtonControl { Text = "Placeholder" };
+        window.AddControl(placeholder);
+
+        var slider = new SliderControl();
+        window.AddControl(slider);
+
+        bool gotFocusFired = false;
+        slider.GotFocus += (_, _) => gotFocusFired = true;
+
+        window.FocusManager.SetFocus(slider, FocusReason.Programmatic);
+
+        Assert.True(gotFocusFired, "GotFocus should fire for SliderControl after Container fix");
+    }
+
+    [Fact]
+    public void SliderControl_LostFocus_Fires_WhenUnfocused()
+    {
+        var system = TestWindowSystemBuilder.CreateTestSystem();
+        var window = new Window(system) { Width = 80, Height = 25 };
+        var placeholder = new ButtonControl { Text = "Placeholder" };
+        window.AddControl(placeholder);
+
+        var slider = new SliderControl();
+        window.AddControl(slider);
+
+        window.FocusManager.SetFocus(slider, FocusReason.Programmatic);
+
+        bool lostFocusFired = false;
+        slider.LostFocus += (_, _) => lostFocusFired = true;
+
+        window.FocusManager.SetFocus(placeholder, FocusReason.Programmatic);
+
+        Assert.True(lostFocusFired, "LostFocus should fire for SliderControl after Container fix");
+    }
+
+    [Fact]
+    public void RangeSliderControl_GotFocus_Fires_WhenFocused()
+    {
+        var system = TestWindowSystemBuilder.CreateTestSystem();
+        var window = new Window(system) { Width = 80, Height = 25 };
+        var placeholder = new ButtonControl { Text = "Placeholder" };
+        window.AddControl(placeholder);
+
+        var slider = new RangeSliderControl();
+        window.AddControl(slider);
+
+        bool gotFocusFired = false;
+        slider.GotFocus += (_, _) => gotFocusFired = true;
+
+        window.FocusManager.SetFocus(slider, FocusReason.Programmatic);
+
+        Assert.True(gotFocusFired, "GotFocus should fire for RangeSliderControl after Container fix");
+    }
+
+    [Fact]
+    public void RangeSliderControl_LostFocus_Fires_WhenUnfocused()
+    {
+        var system = TestWindowSystemBuilder.CreateTestSystem();
+        var window = new Window(system) { Width = 80, Height = 25 };
+        var placeholder = new ButtonControl { Text = "Placeholder" };
+        window.AddControl(placeholder);
+
+        var slider = new RangeSliderControl();
+        window.AddControl(slider);
+
+        window.FocusManager.SetFocus(slider, FocusReason.Programmatic);
+
+        bool lostFocusFired = false;
+        slider.LostFocus += (_, _) => lostFocusFired = true;
+
+        window.FocusManager.SetFocus(placeholder, FocusReason.Programmatic);
+
+        Assert.True(lostFocusFired, "LostFocus should fire for RangeSliderControl after Container fix");
+    }
+
+    [Fact]
+    public void SeparatorControl_Container_DelegatesToBase()
+    {
+        // SeparatorControl is non-interactive/non-focusable, but verify
+        // its Container override delegates to base without errors.
+        var system = TestWindowSystemBuilder.CreateTestSystem();
+        var window = new Window(system) { Width = 80, Height = 25 };
+        var separator = new SeparatorControl();
+        window.AddControl(separator);
+
+        Assert.NotNull(separator.Container);
+    }
+}

--- a/SharpConsoleUI/Controls/BarGraphControl.cs
+++ b/SharpConsoleUI/Controls/BarGraphControl.cs
@@ -32,7 +32,6 @@ namespace SharpConsoleUI.Controls
 
 		private Color? _backgroundColorValue;
 		private int _barWidth = DEFAULT_BAR_WIDTH;
-		private IContainer? _container;
 		private Color _filledColor = Color.Cyan1;
 		private Color? _foregroundColorValue;
 		private string _label = string.Empty;
@@ -236,10 +235,10 @@ namespace SharpConsoleUI.Controls
 		/// <inheritdoc/>
 		public override IContainer? Container
 		{
-			get => _container;
+			get => base.Container;
 			set
 			{
-				_container = value;
+				base.Container = value;
 				OnPropertyChanged();
 				Container?.Invalidate(true);
 			}

--- a/SharpConsoleUI/Controls/HorizontalSplitterControl.cs
+++ b/SharpConsoleUI/Controls/HorizontalSplitterControl.cs
@@ -32,7 +32,6 @@ namespace SharpConsoleUI.Controls
 		private Color? _focusedBackgroundColorValue;
 		private Color? _focusedForegroundColorValue;
 
-		private IContainer? _container;
 		private Window? _subscribedWindow;
 		private bool _isDragging;
 		private bool _isEnabled = true;
@@ -94,10 +93,10 @@ namespace SharpConsoleUI.Controls
 		/// <inheritdoc/>
 		public override IContainer? Container
 		{
-			get => _container;
+			get => base.Container;
 			set
 			{
-				_container = value;
+				base.Container = value;
 				// Only reset resolved neighbors if they weren't explicitly set via constructor/SetNeighbors.
 				// Explicit neighbors remain valid regardless of container changes.
 				if (_aboveControl == null && _belowControl == null)

--- a/SharpConsoleUI/Controls/LineGraphControl/LineGraphControl.cs
+++ b/SharpConsoleUI/Controls/LineGraphControl/LineGraphControl.cs
@@ -119,8 +119,6 @@ namespace SharpConsoleUI.Controls
 		private Color? _borderColor;
 		private Color? _backgroundColorValue;
 		private Color? _foregroundColorValue;
-		private IContainer? _container;
-
 		// Reusable pixel grid to avoid GC pressure in braille mode
 		private bool[,]? _pixelGridCache;
 
@@ -443,10 +441,10 @@ namespace SharpConsoleUI.Controls
 		/// <inheritdoc/>
 		public override IContainer? Container
 		{
-			get => _container;
+			get => base.Container;
 			set
 			{
-				_container = value;
+				base.Container = value;
 				OnPropertyChanged();
 				Container?.Invalidate(true);
 			}

--- a/SharpConsoleUI/Controls/MultilineEdit/MultilineEditControl.cs
+++ b/SharpConsoleUI/Controls/MultilineEdit/MultilineEditControl.cs
@@ -259,8 +259,7 @@ namespace SharpConsoleUI.Controls
 			}
 		}
 
-		/// <inheritdoc/>
-		public override IContainer? Container { get; set; }
+		// Container is inherited from BaseControl — no override needed.
 
 		/// <summary>
 		/// Gets or sets the text content as a single string with line breaks.

--- a/SharpConsoleUI/Controls/ProgressBarControl.cs
+++ b/SharpConsoleUI/Controls/ProgressBarControl.cs
@@ -45,8 +45,7 @@ namespace SharpConsoleUI.Controls
 		private bool _showHeader;
 		private string? _header;
 
-		// Container backing field for custom override
-		private IContainer? _container;
+		// Container override uses base.Container — see Container property below.
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="ProgressBarControl"/> class.
@@ -225,16 +224,16 @@ namespace SharpConsoleUI.Controls
 		/// <inheritdoc/>
 		public override IContainer? Container
 		{
-			get => _container;
+			get => base.Container;
 			set
 			{
 				// Stop animation when removed from container
-				if (value == null && _container != null)
+				if (value == null && base.Container != null)
 					StopAnimation();
 
-				_container = value;
+				base.Container = value;
 				OnPropertyChanged();
-				_container?.Invalidate(true);
+				Container?.Invalidate(true);
 			}
 		}
 

--- a/SharpConsoleUI/Controls/RangeSliderControl/RangeSliderControl.cs
+++ b/SharpConsoleUI/Controls/RangeSliderControl/RangeSliderControl.cs
@@ -56,7 +56,6 @@ namespace SharpConsoleUI.Controls
 		private Color? _thumbColor;
 		private Color? _focusedThumbColor;
 		private Color? _backgroundColorValue;
-		private IContainer? _container;
 		private LayoutRect _lastLayoutBounds;
 
 		#endregion
@@ -351,12 +350,12 @@ namespace SharpConsoleUI.Controls
 		/// <inheritdoc/>
 		public override IContainer? Container
 		{
-			get => _container;
+			get => base.Container;
 			set
 			{
-				_container = value;
+				base.Container = value;
 				OnPropertyChanged();
-				_container?.Invalidate(true);
+				Container?.Invalidate(true);
 			}
 		}
 

--- a/SharpConsoleUI/Controls/SeparatorControl.cs
+++ b/SharpConsoleUI/Controls/SeparatorControl.cs
@@ -22,7 +22,6 @@ namespace SharpConsoleUI.Controls
 
 		private Color? _backgroundColorValue;
 		private char _character = DEFAULT_CHARACTER;
-		private IContainer? _container;
 		private Color? _foregroundColorValue;
 
 		/// <summary>
@@ -59,10 +58,10 @@ namespace SharpConsoleUI.Controls
 		/// <inheritdoc/>
 		public override IContainer? Container
 		{
-			get => _container;
+			get => base.Container;
 			set
 			{
-				_container = value;
+				base.Container = value;
 				OnPropertyChanged();
 				Container?.Invalidate(true);
 			}

--- a/SharpConsoleUI/Controls/SliderControl/SliderControl.cs
+++ b/SharpConsoleUI/Controls/SliderControl/SliderControl.cs
@@ -58,7 +58,6 @@ namespace SharpConsoleUI.Controls
 		private Color? _thumbColor;
 		private Color? _focusedThumbColor;
 		private Color? _backgroundColorValue;
-		private IContainer? _container;
 		private LayoutRect _lastLayoutBounds;
 
 		#endregion
@@ -271,12 +270,12 @@ namespace SharpConsoleUI.Controls
 		/// <inheritdoc/>
 		public override IContainer? Container
 		{
-			get => _container;
+			get => base.Container;
 			set
 			{
-				_container = value;
+				base.Container = value;
 				OnPropertyChanged();
-				_container?.Invalidate(true);
+				Container?.Invalidate(true);
 			}
 		}
 

--- a/SharpConsoleUI/Controls/SparklineControl/SparklineControl.cs
+++ b/SharpConsoleUI/Controls/SparklineControl/SparklineControl.cs
@@ -109,7 +109,6 @@ namespace SharpConsoleUI.Controls
 		private BorderStyle _borderStyle = BorderStyle.None;
 		private SparklineMode _mode = SparklineMode.Block;
 		private Color? _borderColor;
-		private IContainer? _container;
 		private List<double> _dataPoints = new();
 		private Color? _foregroundColorValue;
 		private int _graphHeight = DEFAULT_HEIGHT;
@@ -380,10 +379,10 @@ namespace SharpConsoleUI.Controls
 		/// <inheritdoc/>
 		public override IContainer? Container
 		{
-			get => _container;
+			get => base.Container;
 			set
 			{
-				_container = value;
+				base.Container = value;
 				OnPropertyChanged();
 				Container?.Invalidate(true);
 			}

--- a/SharpConsoleUI/Controls/SplitterControl.cs
+++ b/SharpConsoleUI/Controls/SplitterControl.cs
@@ -27,7 +27,6 @@ namespace SharpConsoleUI.Controls
 
 		private Color? _backgroundColorValue;
 		private Color _borderColor = Color.White;
-		private IContainer? _container;
 		private Window? _subscribedWindow;
 		private Color? _draggingBackgroundColorValue;
 		private Color? _draggingForegroundColorValue;
@@ -84,10 +83,10 @@ namespace SharpConsoleUI.Controls
 		/// <inheritdoc/>
 		public override IContainer? Container
 		{
-			get => _container;
+			get => base.Container;
 			set
 			{
-				_container = value;
+				base.Container = value;
 				Container?.Invalidate(true);
 				var newWindow = this.GetParentWindow();
 				if (!ReferenceEquals(newWindow, _subscribedWindow))


### PR DESCRIPTION
## Summary

- 10 controls overrode `Container` with a local `_container` field, bypassing `BaseControl.SubscribeToFocusManager()` — `GotFocus`/`LostFocus` events were dead on these controls
- Changed all overrides to delegate to `base.Container = value` and removed redundant backing fields
- Added 7 new tests verifying focus events fire correctly for previously-broken interactive controls

Fixes #10

## Test plan

- [x] All 2541 tests pass (2534 existing + 7 new)
- [x] New `ContainerFocusSubscriptionTests` verify GotFocus/LostFocus for MultilineEditControl, SliderControl, RangeSliderControl
- [ ] Manual verification with DemoApp — focus events on slider/edit controls