### PR TITLE
feat: detect non-interactive terminals and fail gracefully

### DIFF
--- a/SharpConsoleUI/Configuration/SystemDefaults.cs
+++ b/SharpConsoleUI/Configuration/SystemDefaults.cs
@@ -45,5 +45,15 @@ namespace SharpConsoleUI.Configuration
 		/// Last Alt+Number window switch key (default: Alt+9)
 		/// </summary>
 		public const ConsoleKey LastWindowSwitchKey = ConsoleKey.D9;
+
+		// Terminal initialization
+		/// <summary>
+		/// Per-byte timeout in milliseconds for DSR terminal verification during startup.
+		/// ReadDSRColumn calls readByte up to ~8 times, so effective worst-case timeout
+		/// is ~8x this value (~4s at 500ms). Longer than the 150ms VS16 probe timeout
+		/// because this is a one-time startup check and some embedded terminals may
+		/// have higher latency.
+		/// </summary>
+		public const int TerminalVerificationTimeoutMs = 500;
 	}
 }

--- a/SharpConsoleUI/Drivers/Input/TerminalRawMode.cs
+++ b/SharpConsoleUI/Drivers/Input/TerminalRawMode.cs
@@ -160,6 +160,29 @@ namespace SharpConsoleUI.Drivers.Input
 		[DllImport("libc", SetLastError = true)]
 		private static extern int poll(ref PollFd fds, int nfds, int timeout);
 
+		[DllImport("libc")]
+		private static extern int isatty(int fd);
+
+		/// <summary>
+		/// Checks whether stdin (fd 0) and stdout (fd 1) are connected to a TTY.
+		/// Returns false for either if piped or redirected.
+		/// Always returns (true, true) on Windows.
+		/// </summary>
+		public static (bool stdinIsTty, bool stdoutIsTty) CheckTtyStatus()
+		{
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+				return (true, true);
+
+			try
+			{
+				return (isatty(StdinFd) == 1, isatty(StdoutFd) == 1);
+			}
+			catch
+			{
+				return (false, false);
+			}
+		}
+
 		/// <summary>
 		/// Reads a single byte from stdin with a timeout using poll() + read().
 		/// Returns -1 on timeout or error. This is the correct way to do

--- a/SharpConsoleUI/Drivers/NetConsoleDriver.cs
+++ b/SharpConsoleUI/Drivers/NetConsoleDriver.cs
@@ -6,6 +6,7 @@
 // License: MIT
 // -----------------------------------------------------------------------
 
+using SharpConsoleUI.Configuration;
 using SharpConsoleUI.Drivers.Input;
 using SharpConsoleUI.Helpers;
 using SharpConsoleUI.Themes;
@@ -342,6 +343,44 @@ namespace SharpConsoleUI.Drivers
 			bool isUnix = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 			_useDirectAnsi = isUnix;
 
+			// Fail fast if stdin or stdout is not a TTY (piped/redirected)
+			if (isUnix)
+			{
+				var (stdinIsTty, stdoutIsTty) = TerminalRawMode.CheckTtyStatus();
+
+				if (!stdinIsTty || !stdoutIsTty)
+				{
+					// Restore signals suppressed in constructor so caller's terminal works
+					RestoreUnixSignal(SigInt);
+					RestoreUnixSignal(SigTstp);
+					if (_processExitHandler != null)
+					{
+						AppDomain.CurrentDomain.ProcessExit -= _processExitHandler;
+						_processExitHandler = null;
+					}
+
+					var term = Environment.GetEnvironmentVariable("TERM") ?? "(unset)";
+					var details = new StringBuilder();
+					details.AppendLine("SharpConsoleUI cannot start: interactive terminal required.");
+					details.AppendLine();
+					details.AppendLine("Current environment:");
+					details.AppendLine($"  TERM = {term}");
+					details.AppendLine($"  stdin is TTY: {stdinIsTty}");
+					details.AppendLine($"  stdout is TTY: {stdoutIsTty}");
+					details.AppendLine();
+					if (!stdinIsTty)
+						details.AppendLine("Problem: stdin is not connected to a terminal (it appears to be piped or redirected).");
+					if (!stdoutIsTty)
+						details.AppendLine("Problem: stdout is not connected to a terminal (it appears to be piped or redirected).");
+					details.AppendLine();
+					details.AppendLine("How to fix:");
+					details.AppendLine("  - Run the application directly in a terminal emulator (e.g., Terminal, iTerm2, Alacritty, Windows Terminal)");
+					details.AppendLine("  - Do not pipe input/output (avoid: echo | app, app | cat, app > file)");
+					details.AppendLine("  - If using an IDE, run in the integrated terminal, not as a background process");
+					throw new TerminalNotSupportedException(details.ToString());
+				}
+			}
+
 			// Enter raw mode before creating console buffer (so ioctl is available)
 			if (_useDirectAnsi)
 			{
@@ -406,6 +445,52 @@ namespace SharpConsoleUI.Drivers
 			// Probe terminal VS16 widening support before input loops start.
 			// Uses DSR cursor position query to measure actual emoji width.
 			ProbeTerminalCapabilities();
+
+			// Mandatory terminal verification: ensure terminal responds to escape sequences.
+			// ProbeTerminalCapabilities (above) swallows failures — this is a hard check.
+			if (_useDirectAnsi)
+			{
+				TerminalRawMode.FlushStdin();
+
+				bool responds = TerminalCapabilities.VerifyTerminalResponds(
+					write: text => TerminalRawMode.WriteStdout(text),
+					readByte: () => TerminalRawMode.ReadByteWithTimeout(
+						SystemDefaults.TerminalVerificationTimeoutMs));
+
+				if (!responds)
+				{
+					var term = Environment.GetEnvironmentVariable("TERM") ?? "(unset)";
+					_consoleWindowSystem?.LogService?.Log(
+						Logging.LogLevel.Error,
+						$"Terminal (TERM={term}) did not respond to DSR verification query. " +
+						"Emergency exit: Ctrl+\\ (SIGQUIT).",
+						"System");
+
+					// Roll back: Stop() handles partial initialization (Task 5 guards)
+					Stop();
+
+					var details = new StringBuilder();
+					details.AppendLine("SharpConsoleUI cannot start: terminal is not responding to escape sequences.");
+					details.AppendLine();
+					details.AppendLine("Current environment:");
+					details.AppendLine($"  TERM = {term}");
+					details.AppendLine($"  Verification: sent DSR query (ESC[6n), no response within {SystemDefaults.TerminalVerificationTimeoutMs}ms");
+					details.AppendLine();
+					details.AppendLine("This means the terminal is not processing ANSI escape sequences, which are");
+					details.AppendLine("required for rendering the UI. The alternate screen buffer likely did not activate.");
+					details.AppendLine();
+					details.AppendLine("Common causes:");
+					details.AppendLine("  - Embedded terminal that does not fully support ANSI (e.g., some IDE terminals)");
+					details.AppendLine("  - Terminal multiplexer misconfiguration (tmux, screen)");
+					details.AppendLine("  - TERM environment variable set incorrectly");
+					details.AppendLine();
+					details.AppendLine("How to fix:");
+					details.AppendLine("  - Run in a standard terminal emulator (Terminal, iTerm2, Alacritty, Windows Terminal)");
+					details.AppendLine("  - Ensure TERM is set correctly (e.g., xterm-256color)");
+					details.AppendLine("  - If stuck, press Ctrl+\\ (SIGQUIT) to force exit");
+					throw new TerminalNotSupportedException(details.ToString());
+				}
+			}
 
 			_lastConsoleWidth = screenSize.Width;
 			_lastConsoleHeight = screenSize.Height;
@@ -533,15 +618,20 @@ namespace SharpConsoleUI.Drivers
 				Console.Error.Flush();
 			}
 
-			Console.Out.Write(cleanupSequence);
-			Console.Out.Flush();
-			Console.ResetColor();
+			// Post-restore Console calls — may fail if Start() partially completed
+			try
+			{
+				Console.Out.Write(cleanupSequence);
+				Console.Out.Flush();
+				Console.ResetColor();
+			}
+			catch { }
 
 			Thread.Sleep(50);
 
 			Cleanup();
 
-			Console.Clear();
+			try { Console.Clear(); } catch { }
 
 			// Restore cursor visibility on shutdown
 			SetCursorVisible(true);
@@ -864,12 +954,21 @@ namespace SharpConsoleUI.Drivers
 		private static extern bool SetConsoleMode(nint hConsoleHandle, uint dwMode);
 
 		// Unix signal constants for direct suppression via libc signal()
-		private const int SigInt = 2;     // Ctrl+C
-		private const int SigTstp = 20;   // Ctrl+Z
+		// SIGINT (2, Ctrl+C) and SIGTSTP (20, Ctrl+Z) are suppressed to prevent
+		// accidental interruption of the UI.
+		// SIGQUIT (3, Ctrl+\) is intentionally NOT suppressed — it serves as
+		// an emergency exit when the application is stuck.
+		private const int SigInt = 2;     // Ctrl+C — suppressed
+		private const int SigTstp = 20;   // Ctrl+Z — suppressed
 
 		private static void SuppressUnixSignal(int signum)
 		{
-			try { _unixSignal(signum, new IntPtr(1)); } catch { }
+			try { _unixSignal(signum, new IntPtr(1)); } catch { } // SIG_IGN = 1
+		}
+
+		private static void RestoreUnixSignal(int signum)
+		{
+			try { _unixSignal(signum, IntPtr.Zero); } catch { } // SIG_DFL = 0
 		}
 
 		[DllImport("libc", EntryPoint = "signal")]

--- a/SharpConsoleUI/Drivers/TerminalNotSupportedException.cs
+++ b/SharpConsoleUI/Drivers/TerminalNotSupportedException.cs
@@ -1,0 +1,49 @@
+// -----------------------------------------------------------------------
+// ConsoleEx - A simple console window system for .NET Core
+//
+// Author: Nikolaos Protopapas
+// Email: nikolaos.protopapas@gmail.com
+// License: MIT
+// -----------------------------------------------------------------------
+
+namespace SharpConsoleUI.Drivers
+{
+	/// <summary>
+	/// Thrown when SharpConsoleUI detects that the terminal environment cannot support
+	/// interactive console UI rendering.
+	/// </summary>
+	/// <remarks>
+	/// <para>Common causes:</para>
+	/// <list type="bullet">
+	///   <item>stdin or stdout is piped/redirected (not connected to a TTY)</item>
+	///   <item>The terminal does not respond to ANSI escape sequences (e.g., DSR query)</item>
+	///   <item>Running inside an embedded terminal that lacks alternate screen buffer support</item>
+	/// </list>
+	/// <para>
+	/// If the application is stuck and this exception was not caught, press Ctrl+\
+	/// (SIGQUIT) to force-exit the process. SIGQUIT is intentionally never suppressed.
+	/// </para>
+	/// </remarks>
+	public class TerminalNotSupportedException : InvalidOperationException
+	{
+		/// <summary>
+		/// Initializes a new instance of <see cref="TerminalNotSupportedException"/>
+		/// with the specified error message.
+		/// </summary>
+		/// <param name="message">A message describing why the terminal is not supported.</param>
+		public TerminalNotSupportedException(string message) : base(message)
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of <see cref="TerminalNotSupportedException"/>
+		/// with the specified error message and inner exception.
+		/// </summary>
+		/// <param name="message">A message describing why the terminal is not supported.</param>
+		/// <param name="innerException">The exception that caused this failure.</param>
+		public TerminalNotSupportedException(string message, Exception innerException)
+			: base(message, innerException)
+		{
+		}
+	}
+}

--- a/SharpConsoleUI/Helpers/TerminalCapabilities.cs
+++ b/SharpConsoleUI/Helpers/TerminalCapabilities.cs
@@ -64,6 +64,28 @@ namespace SharpConsoleUI.Helpers
 			_supportsVS16Widening = null;
 		}
 
+		/// <summary>
+		/// Verifies the terminal responds to a DSR (Device Status Report) query.
+		/// Unlike <see cref="Probe"/> which swallows failures, this returns false
+		/// on timeout — indicating the terminal is not processing escape sequences.
+		/// </summary>
+		/// <param name="write">Action to write escape sequences to the terminal.</param>
+		/// <param name="readByte">Function to read a single byte with timeout. Returns -1 on timeout.</param>
+		/// <returns>True if the terminal responded, false if it timed out.</returns>
+		public static bool VerifyTerminalResponds(Action<string> write, Func<int> readByte)
+		{
+			try
+			{
+				write("\x1b[6n");
+				int col = ReadDSRColumn(readByte);
+				return col >= 0;
+			}
+			catch
+			{
+				return false;
+			}
+		}
+
 		private static bool ProbeVS16(Action<string> write, Func<int> readByte)
 		{
 			// Strategy:


### PR DESCRIPTION
## Summary

- Add early TTY detection via `isatty()` P/Invoke — throws `TerminalNotSupportedException` before entering raw mode if stdin/stdout is piped or redirected
- Add post-initialization DSR verification — confirms terminal actually responds to ANSI escape sequences after alternate screen buffer is activated
- Make `Stop()` robust to partial `Start()` initialization (try/catch around Console calls that may fail)
- Restore suppressed signals (SIGINT, SIGTSTP) when `Start()` throws, so the caller's terminal works normally
- SIGQUIT (`Ctrl+\`) is intentionally never suppressed, serving as emergency exit

Fixes #12

## Test plan

- [x] `dotnet build SharpConsoleUI/SharpConsoleUI.csproj` — 0 warnings, 0 errors
- [x] `dotnet test SharpConsoleUI.Tests/SharpConsoleUI.Tests.csproj` — 2541/2541 passing
- [x] Normal terminal — app starts normally (no regression)
- [x] Piped stdout (`dotnet run --project Example | cat`) — throws TerminalNotSupportedException immediately
- [x] Piped stdin (`echo "" | dotnet run --project Example`) — throws TerminalNotSupportedException immediately
- [x] After exception — Ctrl+C works, cursor visible, echo on, alt screen exited