### PR TITLE
feat(CheckboxControl): customizable checked/unchecked characters

### DIFF
--- a/SharpConsoleUI.Tests/Controls/CheckboxControlTests.cs
+++ b/SharpConsoleUI.Tests/Controls/CheckboxControlTests.cs
@@ -1,0 +1,198 @@
+// -----------------------------------------------------------------------
+// ConsoleEx - A simple console window system for .NET Core
+//
+// Author: Nikolaos Protopapas
+// Email: nikolaos.protopapas@gmail.com
+// License: MIT
+// -----------------------------------------------------------------------
+
+using SharpConsoleUI.Builders;
+using SharpConsoleUI.Controls;
+using Xunit;
+using ControlsFactory = SharpConsoleUI.Builders.Controls;
+
+namespace SharpConsoleUI.Tests.Controls;
+
+public class CheckboxControlTests
+{
+	#region Property defaults and assignment
+
+	[Fact]
+	public void CheckedCharacter_DefaultsToX()
+	{
+		var cb = new CheckboxControl("Label");
+		Assert.Equal("X", cb.CheckedCharacter);
+	}
+
+	[Fact]
+	public void UncheckedCharacter_DefaultsToSpace()
+	{
+		var cb = new CheckboxControl("Label");
+		Assert.Equal(" ", cb.UncheckedCharacter);
+	}
+
+	[Fact]
+	public void CheckedCharacter_CanBeSetToCustomGlyph()
+	{
+		var cb = new CheckboxControl("Label") { CheckedCharacter = "✓" };
+		Assert.Equal("✓", cb.CheckedCharacter);
+	}
+
+	[Fact]
+	public void UncheckedCharacter_CanBeSetToCustomGlyph()
+	{
+		var cb = new CheckboxControl("Label") { UncheckedCharacter = "·" };
+		Assert.Equal("·", cb.UncheckedCharacter);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	public void CheckedCharacter_NullOrEmpty_FallsBackToDefault(string? value)
+	{
+		var cb = new CheckboxControl("Label") { CheckedCharacter = "✓" };
+		cb.CheckedCharacter = value!;
+		Assert.Equal("X", cb.CheckedCharacter);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	public void UncheckedCharacter_NullOrEmpty_FallsBackToDefault(string? value)
+	{
+		var cb = new CheckboxControl("Label") { UncheckedCharacter = "·" };
+		cb.UncheckedCharacter = value!;
+		Assert.Equal(" ", cb.UncheckedCharacter);
+	}
+
+	#endregion
+
+	#region Builder fluent methods
+
+	[Fact]
+	public void WithCheckedCharacter_AppliesToBuiltControl()
+	{
+		var cb = ControlsFactory.Checkbox("Label").WithCheckedCharacter("✓").Build();
+		Assert.Equal("✓", cb.CheckedCharacter);
+	}
+
+	[Fact]
+	public void WithUncheckedCharacter_AppliesToBuiltControl()
+	{
+		var cb = ControlsFactory.Checkbox("Label").WithUncheckedCharacter("·").Build();
+		Assert.Equal("·", cb.UncheckedCharacter);
+	}
+
+	[Fact]
+	public void WithCheckmark_SetsBothCharacters()
+	{
+		var cb = ControlsFactory.Checkbox("Label").WithCheckmark("✓", "·").Build();
+		Assert.Equal("✓", cb.CheckedCharacter);
+		Assert.Equal("·", cb.UncheckedCharacter);
+	}
+
+	[Fact]
+	public void WithCheckmark_DefaultUncheckedIsSpace()
+	{
+		var cb = ControlsFactory.Checkbox("Label").WithCheckmark("✓").Build();
+		Assert.Equal("✓", cb.CheckedCharacter);
+		Assert.Equal(" ", cb.UncheckedCharacter);
+	}
+
+	[Fact]
+	public void Builder_WithoutCharacterMethods_LeavesDefaults()
+	{
+		var cb = ControlsFactory.Checkbox("Label").Build();
+		Assert.Equal("X", cb.CheckedCharacter);
+		Assert.Equal(" ", cb.UncheckedCharacter);
+	}
+
+	#endregion
+
+	#region Rendering
+
+	[Fact]
+	public void Render_CustomCheckedCharacter_AppearsInOutput()
+	{
+		var (system, window) = ContainerTestHelpers.CreateTestEnvironment();
+		var cb = ControlsFactory.Checkbox("Enable")
+			.WithCheckedCharacter("✓")
+			.Checked()
+			.Build();
+		window.AddControl(cb);
+
+		var output = window.RenderAndGetVisibleContent();
+		var plainText = ContainerTestHelpers.StripAnsiCodes(output);
+
+		Assert.Contains("[✓]", plainText);
+		Assert.DoesNotContain("[X]", plainText);
+	}
+
+	[Fact]
+	public void Render_CustomUncheckedCharacter_AppearsInOutput()
+	{
+		var (system, window) = ContainerTestHelpers.CreateTestEnvironment();
+		var cb = ControlsFactory.Checkbox("Enable")
+			.WithUncheckedCharacter("·")
+			.Build();
+		window.AddControl(cb);
+
+		var output = window.RenderAndGetVisibleContent();
+		var plainText = ContainerTestHelpers.StripAnsiCodes(output);
+
+		Assert.Contains("[·]", plainText);
+	}
+
+	[Fact]
+	public void Render_DefaultCharacters_StillProduceXAndSpace()
+	{
+		var (system, window) = ContainerTestHelpers.CreateTestEnvironment();
+		var cb = ControlsFactory.Checkbox("Enable").Checked().Build();
+		window.AddControl(cb);
+
+		var output = window.RenderAndGetVisibleContent();
+		var plainText = ContainerTestHelpers.StripAnsiCodes(output);
+
+		Assert.Contains("[X]", plainText);
+	}
+
+	[Fact]
+	public void Render_ToggleCheckedState_SwitchesBetweenCharacters()
+	{
+		var (system, window) = ContainerTestHelpers.CreateTestEnvironment();
+		var cb = ControlsFactory.Checkbox("Enable")
+			.WithCheckmark("✓", "·")
+			.Build();
+		window.AddControl(cb);
+
+		var uncheckedOutput = ContainerTestHelpers.StripAnsiCodes(window.RenderAndGetVisibleContent());
+		Assert.Contains("[·]", uncheckedOutput);
+		Assert.DoesNotContain("[✓]", uncheckedOutput);
+
+		cb.Toggle();
+		var checkedOutput = ContainerTestHelpers.StripAnsiCodes(window.RenderAndGetVisibleContent());
+		Assert.Contains("[✓]", checkedOutput);
+		Assert.DoesNotContain("[·]", checkedOutput);
+	}
+
+	[Fact]
+	public void Render_MarkupSensitiveCharacter_DoesNotBreakOutput()
+	{
+		// User-supplied "[" must be escaped so it isn't parsed as markup.
+		var (system, window) = ContainerTestHelpers.CreateTestEnvironment();
+		var cb = ControlsFactory.Checkbox("Enable")
+			.WithCheckedCharacter("[")
+			.Checked()
+			.Build();
+		window.AddControl(cb);
+
+		var exception = Record.Exception(() => window.RenderAndGetVisibleContent());
+		Assert.Null(exception);
+
+		var plainText = ContainerTestHelpers.StripAnsiCodes(window.RenderAndGetVisibleContent());
+		Assert.Contains("[[]", plainText);
+		Assert.Contains("Enable", plainText);
+	}
+
+	#endregion
+}

--- a/SharpConsoleUI/Builders/CheckboxBuilder.cs
+++ b/SharpConsoleUI/Builders/CheckboxBuilder.cs
@@ -21,6 +21,8 @@ public sealed class CheckboxBuilder : IControlBuilder<CheckboxControl>
 {
 	private string _label = "Checkbox";
 	private bool _isChecked = false;
+	private string? _checkedCharacter;
+	private string? _uncheckedCharacter;
 	private HorizontalAlignment _alignment = HorizontalAlignment.Left;
 	private VerticalAlignment _verticalAlignment = VerticalAlignment.Top;
 	private Margin _margin = new(0, 0, 0, 0);
@@ -51,6 +53,35 @@ public sealed class CheckboxBuilder : IControlBuilder<CheckboxControl>
 	public CheckboxBuilder Checked(bool isChecked = true)
 	{
 		_isChecked = isChecked;
+		return this;
+	}
+
+	/// <summary>
+	/// Sets the character displayed inside the checkbox when checked (default "X").
+	/// Use any single visible character such as "✓", "✗", or "●".
+	/// </summary>
+	public CheckboxBuilder WithCheckedCharacter(string character)
+	{
+		_checkedCharacter = character;
+		return this;
+	}
+
+	/// <summary>
+	/// Sets the character displayed inside the checkbox when unchecked (default " ").
+	/// </summary>
+	public CheckboxBuilder WithUncheckedCharacter(string character)
+	{
+		_uncheckedCharacter = character;
+		return this;
+	}
+
+	/// <summary>
+	/// Sets both the checked and unchecked characters in a single call.
+	/// </summary>
+	public CheckboxBuilder WithCheckmark(string checkedCharacter, string uncheckedCharacter = " ")
+	{
+		_checkedCharacter = checkedCharacter;
+		_uncheckedCharacter = uncheckedCharacter;
 		return this;
 	}
 
@@ -231,6 +262,11 @@ public sealed class CheckboxBuilder : IControlBuilder<CheckboxControl>
 			Tag = _tag,
 			StickyPosition = _stickyPosition
 		};
+
+		if (_checkedCharacter != null)
+			checkbox.CheckedCharacter = _checkedCharacter;
+		if (_uncheckedCharacter != null)
+			checkbox.UncheckedCharacter = _uncheckedCharacter;
 
 		// Attach standard handler
 		if (_checkedChangedHandler != null)

--- a/SharpConsoleUI/Controls/CheckboxControl.cs
+++ b/SharpConsoleUI/Controls/CheckboxControl.cs
@@ -24,6 +24,7 @@ namespace SharpConsoleUI.Controls
 	{
 		private Color? _backgroundColorValue;
 		private bool _checked = false;
+		private string _checkedCharacter = "X";
 		private Color? _checkmarkColorValue;
 		private Color? _disabledBackgroundColorValue;
 		private Color? _disabledForegroundColorValue;
@@ -33,6 +34,7 @@ namespace SharpConsoleUI.Controls
 		private bool _isEnabled = true;
 		private string _label = "Checkbox";
 		private LayoutRect _lastLayoutBounds;
+		private string _uncheckedCharacter = " ";
 
 		/// <summary>
 	/// Initializes a new instance of the <see cref="CheckboxControl"/> class.
@@ -88,7 +90,7 @@ namespace SharpConsoleUI.Controls
 		private int GetCheckboxWidth()
 		{
 		// Build content with decorators (same as rendering)
-		string checkmark = _checked ? "X" : " ";
+		string checkmark = Parsing.MarkupParser.Escape(_checked ? _checkedCharacter : _uncheckedCharacter);
 		string content = $" [[{checkmark}]] {_label} ";
 
 		int minWidth = Parsing.MarkupParser.StripLength(content);
@@ -120,6 +122,28 @@ namespace SharpConsoleUI.Controls
 					CheckedChanged?.Invoke(this, _checked);
 				}
 			}
+		}
+
+		/// <summary>
+		/// Gets or sets the character displayed inside the checkbox when checked.
+		/// Defaults to "X". Set to any single visible character (e.g. "✓", "✗", "●").
+		/// Empty or null values fall back to the default.
+		/// </summary>
+		public string CheckedCharacter
+		{
+			get => _checkedCharacter;
+			set => SetProperty(ref _checkedCharacter, string.IsNullOrEmpty(value) ? "X" : value);
+		}
+
+		/// <summary>
+		/// Gets or sets the character displayed inside the checkbox when unchecked.
+		/// Defaults to a space. Set to any single visible character.
+		/// Empty or null values fall back to the default.
+		/// </summary>
+		public string UncheckedCharacter
+		{
+			get => _uncheckedCharacter;
+			set => SetProperty(ref _uncheckedCharacter, string.IsNullOrEmpty(value) ? " " : value);
 		}
 
 		/// <summary>
@@ -334,7 +358,7 @@ namespace SharpConsoleUI.Controls
 		public override LayoutSize MeasureDOM(LayoutConstraints constraints)
 		{
 		// Build content with decorators (same as rendering)
-		string checkmark = _checked ? "X" : " ";
+		string checkmark = Parsing.MarkupParser.Escape(_checked ? _checkedCharacter : _uncheckedCharacter);
 		string content = $" [[{checkmark}]] {_label} ";
 
 		int minWidth = Parsing.MarkupParser.StripLength(content);
@@ -383,7 +407,7 @@ namespace SharpConsoleUI.Controls
 			if (targetWidth <= 0) return;
 
 			// Build checkbox content
-			string checkmark = _checked ? "X" : " ";
+			string checkmark = Parsing.MarkupParser.Escape(_checked ? _checkedCharacter : _uncheckedCharacter);
 			string tempContent = $" [[{checkmark}]] {_label} ";
 
 			// Calculate checkbox width with decorators


### PR DESCRIPTION
## Summary
- Add `CheckedCharacter` (default `X`) and `UncheckedCharacter` (default ` `) properties to `CheckboxControl` so callers can swap the glyph displayed inside `[ ]` (e.g. `✓`, `✗`, `●`).
- Expose fluent builder methods `WithCheckedCharacter`, `WithUncheckedCharacter`, and `WithCheckmark(checked, unchecked = " ")`.
- User-supplied characters are passed through `MarkupParser.Escape` so characters like `[` can't break the markup pipeline.

## Usage
```csharp
Controls.Checkbox("Enable feature")
    .WithCheckmark("✓")              // or .WithCheckedCharacter("✗")
    .Checked()
    .Build();

// Or directly on the control
var cb = new CheckboxControl("Auto-save") { CheckedCharacter = "●" };
```

Empty/null assignments revert to the defaults.

## Test plan
- [x] 18 new unit tests in `CheckboxControlTests.cs` cover defaults, property assignment, null/empty fallback, all three builder methods, default-preserving build, and rendered output (custom checked glyph, custom unchecked glyph, default still renders `[X]`, toggling switches glyphs, markup-sensitive `[` escapes safely).
- [x] Full test suite green (3067/3067).
- [x] Solution builds with 0 errors on net8.0 and net9.0.

Closes #19