### PR TITLE
feat(MenuControl): bindable MenuItem + observable Children/Items

### DIFF
--- a/SharpConsoleUI.Tests/Controls/MenuControlTests.cs
+++ b/SharpConsoleUI.Tests/Controls/MenuControlTests.cs
@@ -284,15 +284,17 @@ public class MenuControlTests
     }
 
     [Fact]
-    public void Items_IsSnapshot_NotLiveReference()
+    public void Items_IsLiveCollection_ReflectsSubsequentChanges()
     {
+        // Items is intentionally a live observable collection so VM-driven menus work.
+        // Callers that need a snapshot can call .ToList() themselves.
         var menu = new MenuControl();
         menu.AddItem(new MenuItem { Text = "File" });
-        var snapshot = menu.Items;
+        var reference = menu.Items;
         menu.AddItem(new MenuItem { Text = "Edit" });
-        // Snapshot should still have 1 item
-        Assert.Single(snapshot);
+        Assert.Equal(2, reference.Count);
         Assert.Equal(2, menu.Items.Count);
+        Assert.Same(reference, menu.Items);
     }
 
     #endregion

--- a/SharpConsoleUI.Tests/Controls/MenuItemBindingTests.cs
+++ b/SharpConsoleUI.Tests/Controls/MenuItemBindingTests.cs
@@ -1,0 +1,343 @@
+using System.ComponentModel;
+using System.Drawing;
+using SharpConsoleUI;
+using SharpConsoleUI.Builders;
+using SharpConsoleUI.Controls;
+using SharpConsoleUI.DataBinding;
+using SharpConsoleUI.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpConsoleUI.Tests.Controls;
+
+public class MenuItemBindingTests
+{
+    private sealed class TestVm : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        private bool _canSave = true;
+        public bool CanSave
+        {
+            get => _canSave;
+            set { _canSave = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CanSave))); }
+        }
+
+        private string _label = "Save";
+        public string Label
+        {
+            get => _label;
+            set { _label = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Label))); }
+        }
+    }
+
+    [Fact]
+    public void IsEnabled_SetterRaisesPropertyChanged()
+    {
+        var item = new MenuItem { Text = "A" };
+        string? raised = null;
+        item.PropertyChanged += (_, e) => raised = e.PropertyName;
+
+        item.IsEnabled = false;
+
+        Assert.Equal(nameof(MenuItem.IsEnabled), raised);
+    }
+
+    [Fact]
+    public void IsEnabled_SetterDoesNotRaiseWhenValueUnchanged()
+    {
+        var item = new MenuItem { Text = "A", IsEnabled = true };
+        bool raised = false;
+        item.PropertyChanged += (_, _) => raised = true;
+
+        item.IsEnabled = true;
+
+        Assert.False(raised);
+    }
+
+    [Fact]
+    public void Text_SetterRaisesPropertyChanged()
+    {
+        var item = new MenuItem();
+        string? raised = null;
+        item.PropertyChanged += (_, e) => raised = e.PropertyName;
+
+        item.Text = "Hello";
+
+        Assert.Equal(nameof(MenuItem.Text), raised);
+    }
+
+    [Fact]
+    public void Shortcut_SetterRaisesPropertyChanged()
+    {
+        var item = new MenuItem();
+        string? raised = null;
+        item.PropertyChanged += (_, e) => raised = e.PropertyName;
+
+        item.Shortcut = "Ctrl+S";
+
+        Assert.Equal(nameof(MenuItem.Shortcut), raised);
+    }
+
+    [Fact]
+    public void ForegroundColor_SetterRaisesPropertyChanged()
+    {
+        var item = new MenuItem();
+        string? raised = null;
+        item.PropertyChanged += (_, e) => raised = e.PropertyName;
+
+        item.ForegroundColor = Color.Red;
+
+        Assert.Equal(nameof(MenuItem.ForegroundColor), raised);
+    }
+
+    [Fact]
+    public void Children_IsMenuItemCollection_WithOwnerItemSet()
+    {
+        var parent = new MenuItem { Text = "Parent" };
+        Assert.IsType<MenuItemCollection>(parent.Children);
+        Assert.Same(parent, ((MenuItemCollection)parent.Children).OwnerItem);
+    }
+
+    [Fact]
+    public void Children_FiresCollectionChangedOnAdd()
+    {
+        var parent = new MenuItem { Text = "Parent" };
+        var child = new MenuItem { Text = "Child" };
+
+        System.Collections.Specialized.NotifyCollectionChangedAction? action = null;
+        ((MenuItemCollection)parent.Children).CollectionChanged += (_, e) => action = e.Action;
+
+        parent.Children.Add(child);
+
+        Assert.Equal(System.Collections.Specialized.NotifyCollectionChangedAction.Add, action);
+    }
+
+    [Fact]
+    public void Owner_NullByDefault()
+    {
+        var item = new MenuItem();
+        Assert.Null(item.Owner);
+    }
+
+    [Fact]
+    public void Bindings_LazilyCreated_AndSameInstanceOnSubsequentCalls()
+    {
+        var item = new MenuItem();
+        Assert.NotNull(item.Bindings);
+        Assert.Same(item.Bindings, item.Bindings);
+    }
+
+    [Fact]
+    public void AddingItemToMenu_SetsOwnerOnItem()
+    {
+        var menu = new MenuControl();
+        var item = new MenuItem { Text = "File" };
+
+        menu.AddItem(item);
+
+        Assert.Same(menu, item.Owner);
+    }
+
+    [Fact]
+    public void AddingItemWithPrePopulatedChildren_SetsOwnerRecursively()
+    {
+        var menu = new MenuControl();
+        var parent = new MenuItem { Text = "File" };
+        var child = new MenuItem { Text = "Save" };
+        var grandchild = new MenuItem { Text = "All" };
+        parent.Children.Add(child);
+        child.Children.Add(grandchild);
+
+        menu.AddItem(parent);
+
+        Assert.Same(menu, parent.Owner);
+        Assert.Same(menu, child.Owner);
+        Assert.Same(menu, grandchild.Owner);
+    }
+
+    [Fact]
+    public void RemovingItem_ClearsOwnerAndDisposesBindingsRecursively()
+    {
+        var menu = new MenuControl();
+        var parent = new MenuItem { Text = "File" };
+        var child = new MenuItem { Text = "Save" };
+        parent.Children.Add(child);
+        menu.AddItem(parent);
+
+        parent.Bindings.Add(new DisposableSpy());
+        child.Bindings.Add(new DisposableSpy());
+
+        menu.RemoveItem(parent);
+
+        Assert.Null(parent.Owner);
+        Assert.Null(child.Owner);
+        Assert.Throws<ObjectDisposedException>(() => parent.Bindings.Add(new DisposableSpy()));
+        Assert.Throws<ObjectDisposedException>(() => child.Bindings.Add(new DisposableSpy()));
+    }
+
+    [Fact]
+    public void AddingSameItemToTwoMenus_Throws()
+    {
+        var menu1 = new MenuControl();
+        var menu2 = new MenuControl();
+        var item = new MenuItem { Text = "Shared" };
+
+        menu1.AddItem(item);
+
+        Assert.Throws<InvalidOperationException>(() => menu2.AddItem(item));
+    }
+
+    [Fact]
+    public void AddingChildToAttachedParent_SetsChildOwnerAndParent()
+    {
+        var menu = new MenuControl();
+        var parent = new MenuItem { Text = "File" };
+        menu.AddItem(parent);
+
+        var child = new MenuItem { Text = "New" };
+        parent.Children.Add(child);
+
+        Assert.Same(menu, child.Owner);
+        Assert.Same(parent, child.Parent);
+    }
+
+    [Fact]
+    public void ClearingChildren_DetachesAllAndDisposesBindings()
+    {
+        var menu = new MenuControl();
+        var parent = new MenuItem { Text = "File" };
+        parent.Children.Add(new MenuItem { Text = "A" });
+        parent.Children.Add(new MenuItem { Text = "B" });
+        menu.AddItem(parent);
+
+        var childA = parent.Children[0];
+        childA.Bindings.Add(new DisposableSpy());
+
+        parent.Children.Clear();
+
+        Assert.Null(childA.Owner);
+        Assert.Throws<ObjectDisposedException>(() => childA.Bindings.Add(new DisposableSpy()));
+    }
+
+    [Fact]
+    public void ItemsProperty_IsLiveCollection_AddingDirectlyTriggersAttach()
+    {
+        var menu = new MenuControl();
+        var item = new MenuItem { Text = "Direct" };
+
+        menu.Items.Add(item);
+
+        Assert.Same(menu, item.Owner);
+        Assert.Contains(item, menu.Items);
+    }
+
+    [Fact]
+    public void Bind_OneWay_FlowsSourceToTarget()
+    {
+        var vm = new TestVm { CanSave = false };
+        var item = new MenuItem { Text = "Save" }
+            .Bind(vm, x => x.CanSave, m => m.IsEnabled);
+
+        Assert.False(item.IsEnabled);
+
+        vm.CanSave = true;
+        Assert.True(item.IsEnabled);
+    }
+
+    [Fact]
+    public void Bind_OneWay_WithConverter()
+    {
+        var vm = new TestVm { Label = "Open" };
+        var item = new MenuItem()
+            .Bind(vm, x => x.Label, m => m.Text, label => "> " + label);
+
+        Assert.Equal("> Open", item.Text);
+
+        vm.Label = "Close";
+        Assert.Equal("> Close", item.Text);
+    }
+
+    [Fact]
+    public void BindTwoWay_RoundTripsBothDirections()
+    {
+        var vm = new TestVm { Label = "A" };
+        var item = new MenuItem()
+            .BindTwoWay(vm, x => x.Label, m => m.Text);
+
+        Assert.Equal("A", item.Text);
+
+        vm.Label = "B";
+        Assert.Equal("B", item.Text);
+
+        item.Text = "C";
+        Assert.Equal("C", vm.Label);
+    }
+
+    [Fact]
+    public void DetachingBoundItem_DisposesBindingsAndStopsPropagation()
+    {
+        var menu = new MenuControl();
+        var vm = new TestVm { CanSave = true };
+        var item = new MenuItem { Text = "Save" }
+            .Bind(vm, x => x.CanSave, m => m.IsEnabled);
+        menu.AddItem(item);
+
+        menu.RemoveItem(item);
+
+        // After detach, item.Bindings is disposed. VM mutation must not affect the item
+        // and must not throw.
+        vm.CanSave = false;
+        Assert.True(item.IsEnabled);
+    }
+
+    [Fact]
+    public void MenuItemBuilder_FluentBind_AppliesBindingToBuiltItem()
+    {
+        var vm = new TestVm { CanSave = false };
+
+        var menu = new MenuBuilder()
+            .AddItem("File", m =>
+            {
+                m.AddItem("Save", () => { });
+                m.Bind(vm, x => x.CanSave, mi => mi.IsEnabled);
+            })
+            .Build();
+
+        var fileItem = menu.Items.Single(i => i.Text == "File");
+        Assert.False(fileItem.IsEnabled);
+
+        vm.CanSave = true;
+        Assert.True(fileItem.IsEnabled);
+    }
+
+    [Fact]
+    public void Krokots_MenuItem_IsEnabled_BoundToVm_RoundTrips()
+    {
+        // Issue #21: "MenuItem.IsEnabled bound to a bool so that it can be enabled/disabled
+        // from a view model (for example - loading data enables additional options)."
+        var system = TestWindowSystemBuilder.CreateTestSystem();
+        var window = new Window(system) { Width = 80, Height = 30 };
+        var menu = new MenuControl { Orientation = MenuOrientation.Horizontal };
+        window.AddControl(menu);
+
+        var vm = new TestVm { CanSave = true };
+
+        var saveItem = new MenuItem { Text = "Save" }
+            .Bind(vm, x => x.CanSave, m => m.IsEnabled);
+        menu.AddItem(saveItem);
+
+        Assert.True(saveItem.IsEnabled);
+
+        vm.CanSave = false;
+        Assert.False(saveItem.IsEnabled);
+
+        vm.CanSave = true;
+        Assert.True(saveItem.IsEnabled);
+    }
+
+    private sealed class DisposableSpy : IDisposable
+    {
+        public bool Disposed { get; private set; }
+        public void Dispose() => Disposed = true;
+    }
+}

--- a/SharpConsoleUI.Tests/Controls/MenuItemCollectionTests.cs
+++ b/SharpConsoleUI.Tests/Controls/MenuItemCollectionTests.cs
@@ -1,0 +1,43 @@
+using System.Collections.Specialized;
+using SharpConsoleUI.Controls;
+using Xunit;
+
+namespace SharpConsoleUI.Tests.Controls;
+
+public class MenuItemCollectionTests
+{
+    [Fact]
+    public void Clear_FiresRemoveEventForEachItem_NotJustReset()
+    {
+        var collection = new MenuItemCollection();
+        var a = new MenuItem { Text = "A" };
+        var b = new MenuItem { Text = "B" };
+        collection.Add(a);
+        collection.Add(b);
+
+        var events = new List<NotifyCollectionChangedEventArgs>();
+        collection.CollectionChanged += (_, e) => events.Add(e);
+
+        collection.Clear();
+
+        var removes = events.Where(e => e.Action == NotifyCollectionChangedAction.Remove).ToList();
+        Assert.Equal(2, removes.Count);
+        Assert.Contains(removes, e => e.OldItems != null && e.OldItems.Contains(a));
+        Assert.Contains(removes, e => e.OldItems != null && e.OldItems.Contains(b));
+    }
+
+    [Fact]
+    public void OwnerItem_NullByDefault()
+    {
+        var collection = new MenuItemCollection();
+        Assert.Null(collection.OwnerItem);
+    }
+
+    [Fact]
+    public void OwnerItem_SetViaConstructor()
+    {
+        var parent = new MenuItem { Text = "Parent" };
+        var collection = new MenuItemCollection(parent);
+        Assert.Same(parent, collection.OwnerItem);
+    }
+}

--- a/SharpConsoleUI/Builders/MenuItemBuilder.cs
+++ b/SharpConsoleUI/Builders/MenuItemBuilder.cs
@@ -161,4 +161,11 @@ public class MenuItemBuilder
     /// Builds and returns the configured MenuItem instance.
     /// </summary>
     internal MenuItem Build() => _item;
+
+    /// <summary>
+    /// The MenuItem currently being configured by this builder. Used by
+    /// <see cref="DataBinding.BindingExtensions"/> fluent overloads to attach
+    /// bindings before <see cref="Build"/> is called.
+    /// </summary>
+    internal MenuItem CurrentItem => _item;
 }

--- a/SharpConsoleUI/Controls/MenuControl/MenuControl.cs
+++ b/SharpConsoleUI/Controls/MenuControl/MenuControl.cs
@@ -22,7 +22,7 @@ public partial class MenuControl : BaseControl, IInteractiveControl, IFocusableC
     private bool _enabled = true;
 
     // Menu items
-    private readonly List<MenuItem> _items = new();
+    private readonly MenuItemCollection _items = new();
     private readonly object _menuLock = new();
 
     // State tracking
@@ -48,6 +48,16 @@ public partial class MenuControl : BaseControl, IInteractiveControl, IFocusableC
 
     // Measurement cache (avoid repeated Parsing.MarkupParser.StripLength calls per frame)
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, int> _measurementCache = new();
+
+    #endregion
+
+    #region Construction
+
+    /// <summary>Creates a MenuControl with an empty observable Items collection.</summary>
+    public MenuControl()
+    {
+        _items.CollectionChanged += OnChildrenChanged;
+    }
 
     #endregion
 
@@ -77,12 +87,12 @@ public partial class MenuControl : BaseControl, IInteractiveControl, IFocusableC
     }
 
     /// <summary>
-    /// Gets the list of top-level menu items.
+    /// Gets the live, observable collection of top-level menu items. Mutations
+    /// (Add/Remove/Clear) flow through the binding-aware tree management: items added
+    /// have their Owner set; items removed have their Bindings disposed and any open
+    /// dropdown rooted on them closed.
     /// </summary>
-    public IReadOnlyList<MenuItem> Items
-    {
-        get { lock (_menuLock) { return _items.ToList().AsReadOnly(); } }
-    }
+    public MenuItemCollection Items => _items;
 
     // Menu bar colors (nullable for theme fallback)
     private Color? _menuBarBackgroundColor;
@@ -248,7 +258,7 @@ public partial class MenuControl : BaseControl, IInteractiveControl, IFocusableC
         return _measurementCache.GetOrAdd(text, t => Parsing.MarkupParser.StripLength(t));
     }
 
-    private void InvalidateMeasurementCache()
+    internal void InvalidateMeasurementCache()
     {
         _measurementCache.Clear();
     }
@@ -372,7 +382,7 @@ public partial class MenuControl : BaseControl, IInteractiveControl, IFocusableC
     #region Public Methods - Menu Management
 
     /// <summary>
-    /// Adds a menu item to the menu.
+    /// Adds a menu item to the menu. Equivalent to <c>Items.Add(item)</c>.
     /// </summary>
     public void AddItem(MenuItem item)
     {
@@ -380,49 +390,22 @@ public partial class MenuControl : BaseControl, IInteractiveControl, IFocusableC
             throw new ArgumentNullException(nameof(item));
 
         lock (_menuLock) { _items.Add(item); }
-        InvalidateMeasurementCache();
-        Container?.Invalidate(true);
     }
 
     /// <summary>
-    /// Removes a menu item from the menu.
+    /// Removes a menu item from the menu. Equivalent to <c>Items.Remove(item)</c>.
     /// </summary>
     public void RemoveItem(MenuItem item)
     {
-        bool removed;
-        lock (_menuLock) { removed = _items.Remove(item); }
-        if (removed)
-        {
-            if (_focusedItem == item)
-                _focusedItem = null;
-            if (_hoveredItem == item)
-                _hoveredItem = null;
-            if (_pressedItem == item)
-                _pressedItem = null;
-
-            // Close any open dropdown whose parent is the removed item
-            if (_openDropdowns.Any(d => d.ParentItem == item))
-            {
-                CloseAllMenus();
-            }
-
-            InvalidateMeasurementCache();
-            Container?.Invalidate(true);
-        }
+        lock (_menuLock) { _items.Remove(item); }
     }
 
     /// <summary>
-    /// Removes all menu items.
+    /// Removes all menu items. Equivalent to <c>Items.Clear()</c>.
     /// </summary>
     public void ClearItems()
     {
         lock (_menuLock) { _items.Clear(); }
-        _focusedItem = null;
-        _hoveredItem = null;
-        _pressedItem = null;
-        InvalidateMeasurementCache();
-        CloseAllMenus();
-        Container?.Invalidate(true);
     }
 
     /// <summary>
@@ -432,7 +415,7 @@ public partial class MenuControl : BaseControl, IInteractiveControl, IFocusableC
     {
         var parts = path.Split('/');
         MenuItem? current = null;
-        List<MenuItem> searchList;
+        IList<MenuItem> searchList;
         lock (_menuLock) { searchList = _items.ToList(); }
 
         foreach (var part in parts)
@@ -448,16 +431,14 @@ public partial class MenuControl : BaseControl, IInteractiveControl, IFocusableC
     }
 
     /// <summary>
-    /// Sets whether a menu item is enabled by its path.
+    /// Sets whether a menu item is enabled by its path. The redraw is triggered by the
+    /// bindable <see cref="MenuItem.IsEnabled"/> setter, not by this method.
     /// </summary>
     public void SetItemEnabled(string path, bool enabled)
     {
         var item = FindItemByPath(path);
         if (item != null)
-        {
             item.IsEnabled = enabled;
-            Container?.Invalidate(true);
-        }
     }
 
     /// <summary>
@@ -535,6 +516,64 @@ public partial class MenuControl : BaseControl, IInteractiveControl, IFocusableC
     /// Event fired when a menu item is hovered.
     /// </summary>
     public event EventHandler<MenuItem>? ItemHovered;
+
+    #endregion
+
+    #region Lifecycle (binding-aware tree management)
+
+    private void Attach(MenuItem item)
+    {
+        if (item.Owner != null && item.Owner != this)
+            throw new InvalidOperationException("MenuItem already belongs to a MenuControl.");
+        item.Owner = this;
+        item.InvalidateDepthCache();
+        item.Children.CollectionChanged += OnChildrenChanged;
+        foreach (var child in item.Children)
+        {
+            child.Parent = item;
+            Attach(child);
+        }
+    }
+
+    private void Detach(MenuItem item)
+    {
+        foreach (var child in item.Children)
+            Detach(child);
+        item.Children.CollectionChanged -= OnChildrenChanged;
+        item.Bindings.Dispose();
+        item.Owner = null;
+        item.Parent = null;
+
+        if (_focusedItem == item) _focusedItem = null;
+        if (_hoveredItem == item) _hoveredItem = null;
+        if (_pressedItem == item) _pressedItem = null;
+    }
+
+    private void OnChildrenChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+    {
+        var collection = (MenuItemCollection)sender!;
+
+        if (e.OldItems != null)
+        {
+            foreach (MenuItem item in e.OldItems)
+                Detach(item);
+
+            if (_openDropdowns.Any(d => d.ParentItem != null && e.OldItems.Contains(d.ParentItem)))
+                CloseAllMenus();
+        }
+
+        if (e.NewItems != null)
+        {
+            foreach (MenuItem item in e.NewItems)
+            {
+                item.Parent = collection.OwnerItem;
+                Attach(item);
+            }
+        }
+
+        InvalidateMeasurementCache();
+        Container?.Invalidate(true);
+    }
 
     #endregion
 }

--- a/SharpConsoleUI/Controls/MenuControl/MenuItem.cs
+++ b/SharpConsoleUI/Controls/MenuControl/MenuItem.cs
@@ -1,34 +1,71 @@
-using SharpConsoleUI.Layout;
+using SharpConsoleUI.DataBinding;
+using System.ComponentModel;
 using System.Drawing;
+using System.Runtime.CompilerServices;
 
 namespace SharpConsoleUI.Controls;
 
 /// <summary>
 /// Represents a menu item with support for hierarchical menu structures.
+/// Implements <see cref="INotifyPropertyChanged"/> so display properties can be data-bound
+/// from a view model via <see cref="DataBinding.BindingExtensions"/>.
 /// </summary>
-public class MenuItem
+public class MenuItem : INotifyPropertyChanged
 {
+    /// <inheritdoc/>
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>Creates a MenuItem whose Children collection is owned by this item.</summary>
+    public MenuItem()
+    {
+        Children = new MenuItemCollection(this);
+    }
+
+    private string _text = string.Empty;
+
     /// <summary>
     /// Gets or sets the display text for this menu item.
     /// </summary>
-    public string Text { get; set; } = string.Empty;
+    public string Text
+    {
+        get => _text;
+        set { if (_text == value) return; _text = value; OnPropertyChanged(); Invalidate(measurementChanged: true); }
+    }
+
+    private string? _shortcut;
 
     /// <summary>
     /// Gets or sets the keyboard shortcut text displayed on the right (display only, not handled by MenuControl).
     /// Example: "Ctrl+S", "Alt+F4"
     /// </summary>
-    public string? Shortcut { get; set; }
+    public string? Shortcut
+    {
+        get => _shortcut;
+        set { if (_shortcut == value) return; _shortcut = value; OnPropertyChanged(); Invalidate(measurementChanged: true); }
+    }
+
+    private Color? _foregroundColor;
 
     /// <summary>
     /// Gets or sets the custom foreground color for this menu item.
     /// If set, this color will be used instead of the default menu colors (unless item is disabled or highlighted).
     /// </summary>
-    public Color? ForegroundColor { get; set; }
+    public Color? ForegroundColor
+    {
+        get => _foregroundColor;
+        set { if (Nullable.Equals(_foregroundColor, value)) return; _foregroundColor = value; OnPropertyChanged(); Invalidate(); }
+    }
+
+    private bool _isEnabled = true;
 
     /// <summary>
     /// Gets or sets whether this menu item is enabled. Disabled items are shown but cannot be selected.
     /// </summary>
-    public bool IsEnabled { get; set; } = true;
+    public bool IsEnabled
+    {
+        get => _isEnabled;
+        set { if (_isEnabled == value) return; _isEnabled = value; OnPropertyChanged(); Invalidate(); }
+    }
 
     /// <summary>
     /// Gets or sets whether this menu item is a separator (horizontal line).
@@ -46,9 +83,10 @@ public class MenuItem
     public MenuItem? Parent { get; internal set; }
 
     /// <summary>
-    /// Gets the list of child menu items (submenu).
+    /// Gets the observable list of child menu items (submenu). Mutations are reflected by
+    /// the owning <see cref="MenuControl"/> automatically.
     /// </summary>
-    public List<MenuItem> Children { get; } = new();
+    public MenuItemCollection Children { get; }
 
     /// <summary>
     /// Gets whether this menu item has any children (is a submenu).
@@ -72,6 +110,31 @@ public class MenuItem
     /// Not called for items with children (submenus).
     /// </summary>
     public Action? Action { get; set; }
+
+    /// <summary>
+    /// The <see cref="MenuControl"/> that owns this item (set when the item is attached to a menu tree).
+    /// Null for items not currently in any menu.
+    /// </summary>
+    public MenuControl? Owner { get; internal set; }
+
+    private BindingCollection? _bindings;
+
+    /// <summary>
+    /// Lazily-allocated binding collection. Disposed by <see cref="MenuControl"/> when the item
+    /// is detached from the menu tree.
+    /// </summary>
+    public BindingCollection Bindings => _bindings ??= new BindingCollection();
+
+    /// <summary>Raises <see cref="PropertyChanged"/>.</summary>
+    protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+    private void Invalidate(bool measurementChanged = false)
+    {
+        if (Owner == null) return;
+        if (measurementChanged) Owner.InvalidateMeasurementCache();
+        Owner.Container?.Invalidate(true);
+    }
 
     /// <summary>
     /// Adds a child menu item to this item's submenu.

--- a/SharpConsoleUI/Controls/MenuControl/MenuItemCollection.cs
+++ b/SharpConsoleUI/Controls/MenuControl/MenuItemCollection.cs
@@ -1,0 +1,40 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+
+namespace SharpConsoleUI.Controls;
+
+/// <summary>
+/// Observable collection of MenuItems used for both MenuItem.Children and MenuControl.Items.
+/// Overrides ClearItems so Clear() fires actionable Remove events per item — the base
+/// ObservableCollection only fires a single Reset with no OldItems, which would prevent
+/// MenuControl from detaching items and disposing their bindings.
+/// </summary>
+public sealed class MenuItemCollection : ObservableCollection<MenuItem>
+{
+    /// <summary>
+    /// The MenuItem whose Children this collection represents, or null when this collection
+    /// is the top-level MenuControl.Items. Used to assign Parent on newly-added items in O(1).
+    /// </summary>
+    public MenuItem? OwnerItem { get; }
+
+    /// <summary>Creates a top-level collection (no owning MenuItem).</summary>
+    public MenuItemCollection() { }
+
+    /// <summary>Creates a Children collection owned by the given MenuItem.</summary>
+    public MenuItemCollection(MenuItem? ownerItem)
+    {
+        OwnerItem = ownerItem;
+    }
+
+    /// <inheritdoc/>
+    protected override void ClearItems()
+    {
+        var removed = this.ToList();
+        base.ClearItems();
+        foreach (var item in removed)
+        {
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(
+                NotifyCollectionChangedAction.Remove, item, index: -1));
+        }
+    }
+}

--- a/SharpConsoleUI/DataBinding/BindingExtensions.cs
+++ b/SharpConsoleUI/DataBinding/BindingExtensions.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Linq.Expressions;
+using SharpConsoleUI.Builders;
 using SharpConsoleUI.Controls;
 
 namespace SharpConsoleUI.DataBinding;
@@ -211,6 +212,164 @@ public static class BindingExtensions
 			control.Bindings.Add(binding);
 		});
 
+		return builder;
+	}
+
+	#endregion
+
+	#region One-way binding on MenuItem
+
+	/// <summary>
+	/// Creates a one-way binding from a source property to a <see cref="MenuItem"/> property (same type).
+	/// </summary>
+	public static MenuItem Bind<TSource, TValue>(
+		this MenuItem item,
+		TSource source,
+		Expression<Func<TSource, TValue>> sourceExpr,
+		Expression<Func<MenuItem, TValue>> targetExpr)
+		where TSource : INotifyPropertyChanged
+	{
+		return Bind(item, source, sourceExpr, targetExpr, v => v);
+	}
+
+	/// <summary>
+	/// Creates a one-way binding from a source property to a <see cref="MenuItem"/> property with a converter.
+	/// </summary>
+	public static MenuItem Bind<TSource, TSrc, TTgt>(
+		this MenuItem item,
+		TSource source,
+		Expression<Func<TSource, TSrc>> sourceExpr,
+		Expression<Func<MenuItem, TTgt>> targetExpr,
+		Func<TSrc, TTgt> converter)
+		where TSource : INotifyPropertyChanged
+	{
+		var sourceName = BindingHelper.GetPropertyName(sourceExpr);
+		var sourceGetter = sourceExpr.Compile();
+		var targetSetter = BindingHelper.CreateSetter(targetExpr);
+
+		var binding = new OneWayBinding<TSource, TSrc, TTgt>(
+			source,
+			sourceName,
+			sourceGetter,
+			value => targetSetter(item, value),
+			converter);
+
+		item.Bindings.Add(binding);
+		return item;
+	}
+
+	#endregion
+
+	#region Two-way binding on MenuItem
+
+	/// <summary>
+	/// Creates a two-way binding between a source property and a <see cref="MenuItem"/> property (same type).
+	/// </summary>
+	public static MenuItem BindTwoWay<TSource, TValue>(
+		this MenuItem item,
+		TSource source,
+		Expression<Func<TSource, TValue>> sourceExpr,
+		Expression<Func<MenuItem, TValue>> targetExpr)
+		where TSource : INotifyPropertyChanged
+	{
+		return BindTwoWay(item, source, sourceExpr, targetExpr, v => v, v => v);
+	}
+
+	/// <summary>
+	/// Creates a two-way binding between a source property and a <see cref="MenuItem"/> property with converters.
+	/// </summary>
+	public static MenuItem BindTwoWay<TSource, TSrc, TTgt>(
+		this MenuItem item,
+		TSource source,
+		Expression<Func<TSource, TSrc>> sourceExpr,
+		Expression<Func<MenuItem, TTgt>> targetExpr,
+		Func<TSrc, TTgt> toTarget,
+		Func<TTgt, TSrc> toSource)
+		where TSource : INotifyPropertyChanged
+	{
+		var sourceName = BindingHelper.GetPropertyName(sourceExpr);
+		var targetName = BindingHelper.GetPropertyName(targetExpr);
+		var sourceGetter = sourceExpr.Compile();
+		var sourceSetter = BindingHelper.CreateSetter(sourceExpr);
+		var targetGetter = targetExpr.Compile();
+		var targetSetter = BindingHelper.CreateSetter(targetExpr);
+
+		var binding = new TwoWayBinding<TSource, MenuItem, TSrc, TTgt>(
+			source,
+			sourceName,
+			sourceGetter,
+			value => sourceSetter(source, value),
+			item,
+			targetName,
+			targetGetter,
+			value => targetSetter(item, value),
+			toTarget,
+			toSource);
+
+		item.Bindings.Add(binding);
+		return item;
+	}
+
+	#endregion
+
+	#region Fluent binding on MenuItemBuilder
+
+	/// <summary>
+	/// Creates a one-way binding on the in-progress MenuItem (same type).
+	/// </summary>
+	public static MenuItemBuilder Bind<TSource, TValue>(
+		this MenuItemBuilder builder,
+		TSource source,
+		Expression<Func<TSource, TValue>> sourceExpr,
+		Expression<Func<MenuItem, TValue>> targetExpr)
+		where TSource : INotifyPropertyChanged
+	{
+		builder.CurrentItem.Bind(source, sourceExpr, targetExpr);
+		return builder;
+	}
+
+	/// <summary>
+	/// Creates a one-way binding on the in-progress MenuItem with a converter.
+	/// </summary>
+	public static MenuItemBuilder Bind<TSource, TSrc, TTgt>(
+		this MenuItemBuilder builder,
+		TSource source,
+		Expression<Func<TSource, TSrc>> sourceExpr,
+		Expression<Func<MenuItem, TTgt>> targetExpr,
+		Func<TSrc, TTgt> converter)
+		where TSource : INotifyPropertyChanged
+	{
+		builder.CurrentItem.Bind(source, sourceExpr, targetExpr, converter);
+		return builder;
+	}
+
+	/// <summary>
+	/// Creates a two-way binding on the in-progress MenuItem (same type).
+	/// </summary>
+	public static MenuItemBuilder BindTwoWay<TSource, TValue>(
+		this MenuItemBuilder builder,
+		TSource source,
+		Expression<Func<TSource, TValue>> sourceExpr,
+		Expression<Func<MenuItem, TValue>> targetExpr)
+		where TSource : INotifyPropertyChanged
+	{
+		builder.CurrentItem.BindTwoWay(source, sourceExpr, targetExpr);
+		return builder;
+	}
+
+	/// <summary>
+	/// Creates a two-way binding on the in-progress MenuItem with converters.
+	/// </summary>
+	public static MenuItemBuilder BindTwoWay<TSource, TSrc, TTgt>(
+		this MenuItemBuilder builder,
+		TSource source,
+		Expression<Func<TSource, TSrc>> sourceExpr,
+		Expression<Func<MenuItem, TTgt>> targetExpr,
+		Func<TSrc, TTgt> toTarget,
+		Func<TTgt, TSrc> toSource)
+		where TSource : INotifyPropertyChanged
+	{
+		builder.CurrentItem.BindTwoWay(source, sourceExpr, targetExpr, toTarget, toSource);
 		return builder;
 	}
 


### PR DESCRIPTION
Closes #21.

## What

`MenuItem` is now `INotifyPropertyChanged` and bindable from a VM, so the
example from the issue works:

```csharp
var save = new MenuItem { Text = "Save" }
    .Bind(vm, x => x.CanSave, m => m.IsEnabled);
menu.Items.Add(save);
```

Bindable scalar properties: `Text`, `Shortcut`, `IsEnabled`, `ForegroundColor`.
`Bind` / `BindTwoWay` (with and without converter) on both `MenuItem` directly and
fluent on `MenuItemBuilder` — same API shape as the existing `BaseControl` overloads.

`MenuItem.Children` and `MenuControl.Items` are now `MenuItemCollection`
(`ObservableCollection<MenuItem>`). VM-driven dynamic menus work directly:

```csharp
foreach (var tool in vm.Tools)
    toolsMenu.Children.Add(new MenuItem { Text = tool.Name });
toolsMenu.Children.Clear();
```

## Breaking changes

- `MenuItem.Children`: `List<MenuItem>` → `MenuItemCollection`. Source-compatible for `Add`/`Remove`/`Count`/`foreach`/indexer; `List<T>`-only members (`AddRange`, `RemoveAll`, etc.) are no longer available.
- `MenuControl.Items`: `IReadOnlyList<MenuItem>` snapshot → live `MenuItemCollection`. Source-compatible for iteration / `.Count` / indexer; callers that need a snapshot can call `.ToList()`.

## Tests

- 134 menu tests pass (25 new).
- Full solution: 3092 tests pass.