### PR TITLE
fix(MultilineEditControl): correct cursor/mouse mapping for wide characters

### DIFF
--- a/SharpConsoleUI.Tests/Controls/MultilineEditCursorWidthTests.cs
+++ b/SharpConsoleUI.Tests/Controls/MultilineEditCursorWidthTests.cs
@@ -1,0 +1,157 @@
+// -----------------------------------------------------------------------
+// ConsoleEx - A simple console window system for .NET Core
+//
+// Author: Nikolaos Protopapas
+// Email: nikolaos.protopapas@gmail.com
+// License: MIT
+// -----------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Drawing;
+using SharpConsoleUI.Controls;
+using SharpConsoleUI.Drivers;
+using SharpConsoleUI.Events;
+using SharpConsoleUI.Core;
+using SharpConsoleUI.Tests.Infrastructure;
+using SharpConsoleUI.Windows;
+using Xunit;
+
+namespace SharpConsoleUI.Tests.Controls;
+
+/// <summary>
+/// Regression tests for GitHub issue #23: cursor position is incorrect when the
+/// line contains wide (e.g. CJK) characters. The cursor's screen column must be
+/// measured in DISPLAY columns, not logical UTF-16 character indices, because the
+/// renderer advances 2 columns per wide character.
+/// </summary>
+public class MultilineEditCursorWidthTests
+{
+	private static MultilineEditControl CreateEditing(string content, WrapMode wrapMode = WrapMode.NoWrap)
+	{
+		var control = new MultilineEditControl
+		{
+			WrapMode = wrapMode,
+			Content = content,
+			IsEditing = true
+		};
+		return control;
+	}
+
+	[Fact]
+	public void GetLogicalCursorPosition_CursorAfterWideChars_ReturnsDisplayColumn_NoWrap()
+	{
+		// "中文" = two CJK chars, each 2 display columns wide.
+		// Logical cursor index 2 (end of string) must map to display column 4, not 2.
+		var control = CreateEditing("中文");
+		control.SetLogicalCursorPosition(new Point(2, 0));
+
+		var pos = control.GetLogicalCursorPosition();
+
+		Assert.NotNull(pos);
+		Assert.Equal(4, pos!.Value.X);
+		Assert.Equal(0, pos.Value.Y);
+	}
+
+	[Fact]
+	public void GetLogicalCursorPosition_CursorBetweenWideChars_ReturnsDisplayColumn_NoWrap()
+	{
+		// Cursor after the first CJK char (logical index 1) sits at display column 2.
+		var control = CreateEditing("中文");
+		control.SetLogicalCursorPosition(new Point(1, 0));
+
+		var pos = control.GetLogicalCursorPosition();
+
+		Assert.NotNull(pos);
+		Assert.Equal(2, pos!.Value.X);
+	}
+
+	[Fact]
+	public void GetLogicalCursorPosition_MixedNarrowAndWide_ReturnsDisplayColumn_NoWrap()
+	{
+		// "ab中" = a(1) + b(1) + 中(2). Cursor at logical index 3 (end) => display column 4.
+		var control = CreateEditing("ab中");
+		control.SetLogicalCursorPosition(new Point(3, 0));
+
+		var pos = control.GetLogicalCursorPosition();
+
+		Assert.NotNull(pos);
+		Assert.Equal(4, pos!.Value.X);
+	}
+
+	[Fact]
+	public void GetLogicalCursorPosition_NarrowOnly_Unchanged_NoWrap()
+	{
+		// Pure ASCII: logical index already equals display column. Guards against regression.
+		var control = CreateEditing("hello");
+		control.SetLogicalCursorPosition(new Point(3, 0));
+
+		var pos = control.GetLogicalCursorPosition();
+
+		Assert.NotNull(pos);
+		Assert.Equal(3, pos!.Value.X);
+	}
+
+	#region Mouse positioning (display column -> logical char index)
+
+	private static (ConsoleWindowSystem system, MultilineEditControl control) CreateFocusedInWindow(string content)
+	{
+		var system = TestWindowSystemBuilder.CreateTestSystem();
+		var window = new Window(system);
+		var control = new MultilineEditControl { WrapMode = WrapMode.NoWrap, Content = content };
+
+		window.AddControl(control);
+		system.WindowStateService.AddWindow(window);
+		system.WindowStateService.SetActiveWindow(window);
+		window.FocusManager.SetFocus(control, FocusReason.Programmatic);
+		system.Render.UpdateDisplay();
+		return (system, control);
+	}
+
+	private static MouseEventArgs Press(int controlRelativeX, int controlRelativeY)
+	{
+		var pos = new Point(controlRelativeX, controlRelativeY);
+		return new MouseEventArgs(
+			new List<MouseFlags> { MouseFlags.Button1Pressed },
+			pos, pos, pos);
+	}
+
+	[Fact]
+	public void MouseClick_OnSecondWideChar_PlacesCursorAtCorrectLogicalIndex()
+	{
+		// "中文" renders across display columns 0-3. Clicking at display column 2
+		// (start of 文) must place the logical cursor at char index 1, not 2.
+		var (_, control) = CreateFocusedInWindow("中文");
+
+		control.ProcessMouseEvent(Press(2, 0));
+
+		Assert.Equal(2, control.CurrentColumn); // CurrentColumn is 1-based => logical index 1
+	}
+
+	[Fact]
+	public void MouseClick_PastAllWideChars_PlacesCursorAtEnd()
+	{
+		// Clicking at display column 4 (end of "中文") must land at logical index 2 (end).
+		var (_, control) = CreateFocusedInWindow("中文");
+
+		control.ProcessMouseEvent(Press(4, 0));
+
+		Assert.Equal(3, control.CurrentColumn); // 1-based => logical index 2
+	}
+
+	[Fact]
+	public void MouseDragSelection_AcrossWideChars_SelectsExpectedText()
+	{
+		// Press at column 0, drag to column 2 (start of 文) selects only "中".
+		var (_, control) = CreateFocusedInWindow("中文ab");
+
+		control.ProcessMouseEvent(Press(0, 0));
+		var dragPos = new Point(2, 0);
+		control.ProcessMouseEvent(new MouseEventArgs(
+			new List<MouseFlags> { MouseFlags.Button1Dragged },
+			dragPos, dragPos, dragPos));
+
+		Assert.Equal("中", control.GetSelectedText());
+	}
+
+	#endregion
+}

--- a/SharpConsoleUI/Controls/MultilineEdit/MultilineEditControl.Mouse.cs
+++ b/SharpConsoleUI/Controls/MultilineEdit/MultilineEditControl.Mouse.cs
@@ -447,7 +447,10 @@ namespace SharpConsoleUI.Controls
 				if (_wrapMode == WrapMode.NoWrap)
 				{
 					_cursorY = Math.Min(_lines.Count - 1, relY + _verticalScrollOffset);
-					_cursorX = Math.Min(_lines[_cursorY].Length, relX + _horizontalScrollOffset);
+					// relX is a display column; convert to a logical char index so wide
+					// (e.g. CJK) characters map correctly. See GitHub issue #23.
+					int targetColumn = GetDisplayColumn(_cursorY, _horizontalScrollOffset) + relX;
+					_cursorX = GetCharOffsetFromColumn(_cursorY, targetColumn);
 				}
 				else
 				{
@@ -456,7 +459,10 @@ namespace SharpConsoleUI.Controls
 
 					var wl = wrappedLines[wrappedIndex];
 					_cursorY = wl.SourceLineIndex;
-					_cursorX = Math.Min(wl.SourceCharOffset + relX, wl.SourceCharOffset + wl.Length);
+					// relX is a display column within the wrapped segment; convert it to a
+					// logical char index, then clamp to the segment end.
+					int targetColumn = GetDisplayColumn(_cursorY, wl.SourceCharOffset) + relX;
+					_cursorX = Math.Min(GetCharOffsetFromColumn(_cursorY, targetColumn), wl.SourceCharOffset + wl.Length);
 					_cursorX = Math.Min(_cursorX, _lines[_cursorY].Length);
 				}
 			}

--- a/SharpConsoleUI/Controls/MultilineEdit/MultilineEditControl.Navigation.cs
+++ b/SharpConsoleUI/Controls/MultilineEdit/MultilineEditControl.Navigation.cs
@@ -8,6 +8,7 @@
 
 using SharpConsoleUI.Configuration;
 using SharpConsoleUI.Extensions;
+using SharpConsoleUI.Helpers;
 using System.Drawing;
 using System.Text;
 
@@ -388,8 +389,13 @@ namespace SharpConsoleUI.Controls
 
 			if (_wrapMode == WrapMode.NoWrap)
 			{
+				// Convert logical char offsets to display columns so wide (e.g. CJK)
+				// characters — which the renderer draws 2 columns wide — don't shift
+				// the cursor. See GitHub issue #23.
+				int cursorColumn = GetDisplayColumn(_cursorY, _cursorX);
+				int scrollColumn = GetDisplayColumn(_cursorY, _horizontalScrollOffset);
 				return new Point(
-					Margin.Left + gutterWidth + _cursorX - _horizontalScrollOffset,
+					Margin.Left + gutterWidth + cursorColumn - scrollColumn,
 					Margin.Top + _cursorY - _verticalScrollOffset);
 			}
 			else
@@ -400,9 +406,91 @@ namespace SharpConsoleUI.Controls
 				if (wrappedIndex < 0) return null;
 
 				int visualY = wrappedIndex - _verticalScrollOffset;
-				int visualX = _cursorX - wrappedLines[wrappedIndex].SourceCharOffset;
+				// Measure the display width of the segment text preceding the cursor
+				// rather than the raw char count, so wide characters render correctly.
+				int segmentStart = wrappedLines[wrappedIndex].SourceCharOffset;
+				int visualX = GetDisplayColumn(_cursorY, _cursorX) - GetDisplayColumn(_cursorY, segmentStart);
 
 				return new Point(Margin.Left + gutterWidth + visualX, Margin.Top + visualY);
+			}
+		}
+
+		/// <summary>
+		/// Converts a logical character offset on the given source line into a display-column
+		/// offset, accounting for wide characters that occupy two terminal columns.
+		/// </summary>
+		/// <param name="lineIndex">The source line index.</param>
+		/// <param name="charOffset">The logical (UTF-16) character offset into the line.</param>
+		/// <returns>The display-column offset measured from the start of the line.</returns>
+		private int GetDisplayColumn(int lineIndex, int charOffset)
+		{
+			if (charOffset <= 0)
+				return 0;
+
+			lock (_contentLock)
+			{
+				if (lineIndex < 0 || lineIndex >= _lines.Count)
+					return charOffset;
+
+				string line = _lines[lineIndex];
+				if (charOffset >= line.Length)
+					return UnicodeWidth.GetStringWidth(line);
+
+				return UnicodeWidth.GetStringWidth(line.Substring(0, charOffset));
+			}
+		}
+
+		/// <summary>
+		/// Converts a display-column offset on the given source line into a logical character
+		/// offset. A click landing on either cell of a wide character resolves to that
+		/// character's start. Used to translate mouse coordinates into cursor positions.
+		/// </summary>
+		/// <param name="lineIndex">The source line index.</param>
+		/// <param name="targetColumn">The display-column offset measured from the start of the line.</param>
+		/// <returns>The logical (UTF-16) character offset closest to the target column.</returns>
+		private int GetCharOffsetFromColumn(int lineIndex, int targetColumn)
+		{
+			if (targetColumn <= 0)
+				return 0;
+
+			lock (_contentLock)
+			{
+				if (lineIndex < 0 || lineIndex >= _lines.Count)
+					return targetColumn;
+
+				string line = _lines[lineIndex];
+				int column = 0;
+				int charOffset = 0;
+				Rune? lastMeasured = null;
+
+				foreach (var rune in line.EnumerateRunes())
+				{
+					int runeCharLen = rune.Utf16SequenceLength;
+
+					// Mirror UnicodeWidth.GetStringWidth: a VS16 after a widenable emoji
+					// adds 1 column to the previous rune rather than starting a new cell.
+					if (UnicodeWidth.IsVS16(rune) && lastMeasured != null &&
+						UnicodeWidth.IsVs16Widened(lastMeasured.Value))
+					{
+						column += 1;
+						charOffset += runeCharLen;
+						lastMeasured = null;
+						if (column >= targetColumn) return charOffset;
+						continue;
+					}
+
+					int rw = UnicodeWidth.GetRuneWidth(rune);
+					if (rw > 0) lastMeasured = rune;
+
+					// If the target column falls within this rune's cells, snap to its start.
+					if (column + rw > targetColumn)
+						return charOffset;
+
+					column += rw;
+					charOffset += runeCharLen;
+				}
+
+				return charOffset; // past end of line
 			}
 		}
 


### PR DESCRIPTION
Fixes #23.

## Problem
`MultilineEditControl` stores cursor and selection positions as **logical UTF-16 character indices**, but the renderer draws wide characters (CJK, emoji) across **2 terminal columns**. Two places conflated the two coordinate systems:

1. **`GetLogicalCursorPosition()`** (cursor drawing) used `_cursorX` directly as a display column — the visual cursor drifted left by one column per preceding wide character. This is the bug reported in #23 (typing/pasting `中文`).
2. **`PositionCursorFromMouseCore()`** (mouse click/drag) used the mouse display column directly as a logical char index — the dual bug, which corrupts mouse-driven selection/copy/cut/paste.

## Fix
- Add `GetDisplayColumn(line, charOffset)` — logical char offset → display column (via `UnicodeWidth.GetStringWidth`).
- Add `GetCharOffsetFromColumn(line, targetColumn)` — the inverse, snapping a click on either cell of a wide char to that char's start.
- Both mirror `UnicodeWidth`'s VS16-widening logic.
- Use them in cursor rendering (NoWrap + Wrap paths) and mouse positioning.

Keyboard selection, copy, cut, paste and replace already operated purely on logical char indices/string content and remain correct; mouse selection was the only wide-char defect there and is now fixed.

## Tests
New `MultilineEditCursorWidthTests.cs` (7 tests, written test-first):
- Cursor display-column mapping after / between wide chars (NoWrap)
- Mixed narrow+wide content
- ASCII regression guard
- Mouse click and drag-selection across wide chars

Results:
- New tests: **7/7 pass**
- Full suite: **3099/3099 pass**, no regressions
- Release build: succeeded, 0 errors

No public API changes — backward compatible.