### PR TITLE
feat(dialogs): drive/location picker for file & folder dialogs (#26)

### DIFF
--- a/SharpConsoleUI.Tests/Dialogs/DrivePickerDialogTests.cs
+++ b/SharpConsoleUI.Tests/Dialogs/DrivePickerDialogTests.cs
@@ -1,0 +1,151 @@
+// -----------------------------------------------------------------------
+// ConsoleEx - A simple console window system for .NET Core
+//
+// Author: Nikolaos Protopapas
+// Email: nikolaos.protopapas@gmail.com
+// License: MIT
+// -----------------------------------------------------------------------
+using System;
+using SharpConsoleUI;
+using SharpConsoleUI.Controls;
+using SharpConsoleUI.Dialogs;
+using SharpConsoleUI.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpConsoleUI.Tests.Dialogs;
+
+public class DrivePickerDialogTests
+{
+	private static ConsoleKeyInfo CtrlD()
+		=> new ConsoleKeyInfo('', ConsoleKey.D, shift: false, alt: false, control: true);
+
+	private static ConsoleKeyInfo Esc()
+		=> new ConsoleKeyInfo('', ConsoleKey.Escape, shift: false, alt: false, control: false);
+
+	[Fact]
+	public void FolderPicker_CtrlD_PopulatesFolderListWithPlaces()
+	{
+		var sys = TestWindowSystemBuilder.CreateTestSystem(100, 30);
+
+		// Launch the dialog (do not await — it completes when the modal closes).
+		_ = FolderPickerDialog.ShowAsync(sys, startPath: Environment.CurrentDirectory);
+
+		var modal = sys.WindowStateService.ActiveWindow;
+		Assert.NotNull(modal);
+		var folderList = modal!.FindControl<ListControl>("FolderList");
+		Assert.NotNull(folderList);
+
+		// Send Ctrl+D via the preview hook (fires before the focused list).
+		modal.OnPreviewKeyPressed(CtrlD());
+
+		// The list should now contain at least the root place, and every item's
+		// Tag should be a string path (Places mode), not a FolderEntry.
+		Assert.NotEmpty(folderList!.Items);
+		Assert.All(folderList.Items, i => Assert.IsType<string>(i.Tag));
+
+		// Esc returns to browsing (does NOT close the dialog).
+		modal.OnPreviewKeyPressed(Esc());
+		modal.Close();
+	}
+
+	[Fact]
+	public void FolderPicker_Esc_InPlacesMode_ReturnsToBrowsing_DoesNotClose()
+	{
+		var sys = TestWindowSystemBuilder.CreateTestSystem(100, 30);
+		_ = FolderPickerDialog.ShowAsync(sys, startPath: Environment.CurrentDirectory);
+
+		var modal = sys.WindowStateService.ActiveWindow!;
+		var folderList = modal.FindControl<ListControl>("FolderList")!;
+
+		modal.OnPreviewKeyPressed(CtrlD());
+		// In Places mode the tags are bare string paths.
+		Assert.All(folderList.Items, i => Assert.IsType<string>(i.Tag));
+
+		// Esc in Places mode: handled, returns to browsing, modal still active.
+		bool handled = modal.OnPreviewKeyPressed(Esc());
+		Assert.True(handled);
+		Assert.Same(modal, sys.WindowStateService.ActiveWindow); // not closed
+		// Back to normal browsing: '..' parent entry tag is a FolderEntry, not a string.
+		Assert.Contains(folderList.Items, i => i.Tag is not string && i.Tag is not null);
+
+		modal.Close();
+	}
+
+	[Fact]
+	public void FolderPicker_EnterOnPlace_NavigatesAndExitsPlacesMode()
+	{
+		// Start somewhere with a known parent so a place ("/" or a drive root) exists.
+		var sys = TestWindowSystemBuilder.CreateTestSystem(100, 30);
+		_ = FolderPickerDialog.ShowAsync(sys, startPath: Environment.CurrentDirectory);
+
+		var modal = sys.WindowStateService.ActiveWindow!;
+		var folderList = modal.FindControl<ListControl>("FolderList")!;
+
+		modal.OnPreviewKeyPressed(CtrlD());
+
+		// Pick a place whose path is an existing directory and activate it via Enter.
+		int idx = -1;
+		for (int i = 0; i < folderList.Items.Count; i++)
+		{
+			if (folderList.Items[i].Tag is string p && System.IO.Directory.Exists(p)) { idx = i; break; }
+		}
+		Assert.True(idx >= 0, "expected at least one existing place directory");
+		folderList.SelectedIndex = idx;
+
+		var placePath = (string)folderList.Items[idx].Tag!;
+
+		// Enter through the list's own key processing raises ItemActivated.
+		folderList.ProcessKey(new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false));
+
+		// Back in browsing mode: the footer reverted from the Places hint.
+		var footer = modal.FindControl<MarkupControl>("FooterHint")!;
+		Assert.DoesNotContain("Back to browsing", footer.Text);
+		Assert.Contains("Ctrl+D: Places", footer.Text);
+
+		// And the path display now reflects the place we navigated into.
+		var pathCtrl = modal.FindControl<MarkupControl>("PathDisplay")!;
+		var (seg, _) = DrivePlaces.SplitDriveSegment(placePath);
+		Assert.Contains(seg.Replace("[", "[["), pathCtrl.Text);
+
+		modal.Close();
+	}
+
+	[Fact]
+	public void SaveDialog_CtrlD_WorksEvenWithFilenameFieldFocused()
+	{
+		var sys = TestWindowSystemBuilder.CreateTestSystem(100, 30);
+		_ = FileDialogs.ShowSaveFileAsync(sys, startPath: Environment.CurrentDirectory, defaultFileName: "untitled.txt");
+
+		var modal = sys.WindowStateService.ActiveWindow;
+		Assert.NotNull(modal);
+		var folderList = modal!.FindControl<ListControl>("FolderList");
+		Assert.NotNull(folderList);
+
+		// Ctrl+D should enter Places mode regardless of focus.
+		modal.OnPreviewKeyPressed(CtrlD());
+		Assert.NotEmpty(folderList!.Items);
+		Assert.All(folderList.Items, i =>
+			Assert.StartsWith("PLACE:", Assert.IsType<string>(i.Tag)));
+
+		modal.Close();
+	}
+
+	[Fact]
+	public void FilePicker_CtrlD_EntersPlacesMode()
+	{
+		var sys = TestWindowSystemBuilder.CreateTestSystem(100, 30);
+		_ = FileDialogs.ShowFilePickerAsync(sys, startPath: Environment.CurrentDirectory);
+
+		var modal = sys.WindowStateService.ActiveWindow;
+		Assert.NotNull(modal);
+		var folderList = modal!.FindControl<ListControl>("FolderList");
+		Assert.NotNull(folderList);
+
+		modal.OnPreviewKeyPressed(CtrlD());
+		Assert.NotEmpty(folderList!.Items);
+		Assert.All(folderList.Items, i =>
+			Assert.StartsWith("PLACE:", Assert.IsType<string>(i.Tag)));
+
+		modal.Close();
+	}
+}

--- a/SharpConsoleUI.Tests/Dialogs/DrivePlacesTests.cs
+++ b/SharpConsoleUI.Tests/Dialogs/DrivePlacesTests.cs
@@ -1,0 +1,163 @@
+// -----------------------------------------------------------------------
+// ConsoleEx - A simple console window system for .NET Core
+//
+// Author: Nikolaos Protopapas
+// Email: nikolaos.protopapas@gmail.com
+// License: MIT
+// -----------------------------------------------------------------------
+using System.Collections.Generic;
+using System.Linq;
+using SharpConsoleUI.Dialogs;
+using Xunit;
+
+namespace SharpConsoleUI.Tests.Dialogs;
+
+public class DrivePlacesTests
+{
+	// A synthetic drive record so tests never depend on the host mount table.
+	private static DrivePlaces.RawDrive Raw(string root, string label, string type, bool ready = true)
+		=> new DrivePlaces.RawDrive(root, label, type, ready, 0, 0);
+
+	[Fact]
+	public void Linux_KeepsRootAndMedia_ExcludesVirtualFs()
+	{
+		var drives = new List<DrivePlaces.RawDrive>
+		{
+			Raw("/", "", "Fixed"),
+			Raw("/proc", "", "Ram"),
+			Raw("/sys", "", "Ram"),
+			Raw("/snap/btop/998", "", "Fixed"),
+			Raw("/var/lib/docker/overlay2/abc/merged", "", "Unknown", ready: false),
+			Raw("/boot/efi", "", "Fixed"),
+			Raw("/media/usb", "USB DRIVE", "Removable"),
+			Raw("/mnt/nas", "", "Network"),
+		};
+
+		var places = DrivePlaces.GetPlaces(currentPath: "/home/nick", drives: drives, isWindows: false, homePath: "/home/nick");
+		var paths = places.Select(p => p.Path).ToList();
+
+		Assert.Contains("/", paths);
+		Assert.Contains("/media/usb", paths);
+		Assert.Contains("/mnt/nas", paths);
+		Assert.DoesNotContain("/proc", paths);
+		Assert.DoesNotContain("/sys", paths);
+		Assert.DoesNotContain("/snap/btop/998", paths);
+		Assert.DoesNotContain("/var/lib/docker/overlay2/abc/merged", paths);
+		Assert.DoesNotContain("/boot/efi", paths);
+	}
+
+	[Fact]
+	public void Windows_IncludesAllReadyDrives()
+	{
+		var drives = new List<DrivePlaces.RawDrive>
+		{
+			Raw("C:\\", "Local Disk", "Fixed"),
+			Raw("D:\\", "Data", "Fixed"),
+			Raw("E:\\", "USB DRIVE", "Removable"),
+			Raw("Z:\\", "", "Network"),
+		};
+
+		var places = DrivePlaces.GetPlaces("C:\\Users\\nick", drives, isWindows: true, homePath: "C:\\Users\\nick");
+		var paths = places.Select(p => p.Path).ToList();
+
+		Assert.Contains("C:\\", paths);
+		Assert.Contains("D:\\", paths);
+		Assert.Contains("E:\\", paths);
+		Assert.Contains("Z:\\", paths);
+	}
+
+	[Fact]
+	public void HomeEntry_AddedOnAllPlatforms()
+	{
+		var drives = new List<DrivePlaces.RawDrive> { Raw("/", "", "Fixed") };
+		var places = DrivePlaces.GetPlaces("/", drives, isWindows: false, homePath: "/home/nick");
+		Assert.Contains(places, p => p.DisplayName == "Home" && p.Path == "/home/nick");
+	}
+
+	[Fact]
+	public void CurrentPlace_IsLongestPrefixMatch()
+	{
+		var drives = new List<DrivePlaces.RawDrive>
+		{
+			Raw("/", "", "Fixed"),
+			Raw("/media/usb", "USB", "Removable"),
+		};
+		// /media/usb/photos should resolve to /media/usb, NOT / .
+		var places = DrivePlaces.GetPlaces("/media/usb/photos", drives, isWindows: false, homePath: null);
+		var current = places.Single(p => p.IsCurrent);
+		Assert.Equal("/media/usb", current.Path);
+	}
+
+	[Fact]
+	public void Icons_MatchDriveType()
+	{
+		var drives = new List<DrivePlaces.RawDrive>
+		{
+			Raw("/media/usb", "USB", "Removable"),
+			Raw("/mnt/nas", "", "Network"),
+			Raw("/media/cd", "", "CDRom"),
+			Raw("/", "", "Fixed"),
+		};
+		var places = DrivePlaces.GetPlaces("/", drives, isWindows: false, homePath: null);
+		Assert.Equal("🔌", places.Single(p => p.Path == "/media/usb").Icon);
+		Assert.Equal("🌐", places.Single(p => p.Path == "/mnt/nas").Icon);
+		Assert.Equal("💿", places.Single(p => p.Path == "/media/cd").Icon);
+		Assert.Equal("💾", places.Single(p => p.Path == "/").Icon);
+	}
+
+	[Fact]
+	public void DuplicateMountRoots_AreDeduplicated()
+	{
+		// The OS can report the same network mount twice.
+		var drives = new List<DrivePlaces.RawDrive>
+		{
+			Raw("/", "", "Fixed"),
+			Raw("/mnt/nas", "/mnt/nas", "Network"),
+			Raw("/mnt/nas", "/mnt/nas", "Network"),
+		};
+		var places = DrivePlaces.GetPlaces("/", drives, isWindows: false, homePath: null);
+		Assert.Single(places.Where(p => p.Path == "/mnt/nas"));
+	}
+
+	[Fact]
+	public void Detail_DoesNotRepeatPathWhenLabelEqualsRoot()
+	{
+		var drives = new List<DrivePlaces.RawDrive>
+		{
+			new DrivePlaces.RawDrive("/mnt/nas", "/mnt/nas", "Network", true, 100, 50),
+		};
+		var places = DrivePlaces.GetPlaces("/", drives, isWindows: false, homePath: null);
+		var nas = places.Single(p => p.Path == "/mnt/nas");
+		// Detail should be "Network · ... free", not "/mnt/nas · ... free".
+		Assert.StartsWith("Network", nas.Detail);
+		Assert.DoesNotContain("/mnt/nas", nas.Detail);
+	}
+
+	[Fact]
+	public void RealEnumeration_IsNonEmpty_AndExcludesBlacklist()
+	{
+		// CI-SAFE: asserts invariants only, never specific removable drives,
+		// because the host/CI mount table is non-deterministic.
+		var places = DrivePlaces.GetPlaces(currentPath: System.Environment.CurrentDirectory);
+		Assert.NotEmpty(places);
+		foreach (var p in places)
+		{
+			Assert.DoesNotContain("/proc", p.Path);
+			Assert.DoesNotContain("/sys/", p.Path);
+			Assert.DoesNotContain("/snap/", p.Path);
+			Assert.DoesNotContain("/var/lib/docker", p.Path);
+		}
+	}
+
+	[Theory]
+	[InlineData("C:\\Users\\nick\\Documents", "C:", "\\Users\\nick\\Documents")]
+	[InlineData("/media/usb/photos", "/media/usb", "/photos")]
+	[InlineData("/home/nick", "/", "home/nick")]
+	[InlineData("/", "/", "")]
+	public void SplitDriveSegment_SeparatesRootFromRemainder(string path, string expectedSeg, string expectedRest)
+	{
+		var (seg, rest) = DrivePlaces.SplitDriveSegment(path);
+		Assert.Equal(expectedSeg, seg);
+		Assert.Equal(expectedRest, rest);
+	}
+}

--- a/SharpConsoleUI/Dialogs/DrivePlaces.cs
+++ b/SharpConsoleUI/Dialogs/DrivePlaces.cs
@@ -1,0 +1,264 @@
+// -----------------------------------------------------------------------
+// ConsoleEx - A simple console window system for .NET Core
+//
+// Author: Nikolaos Protopapas
+// Email: nikolaos.protopapas@gmail.com
+// License: MIT
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace SharpConsoleUI.Dialogs;
+
+/// <summary>
+/// OS-aware enumeration of drives / mount points ("places") for the file and
+/// folder picker dialogs. Centralized here so the three dialogs share one
+/// implementation (no duplication).
+/// </summary>
+internal static class DrivePlaces
+{
+	/// <summary>A drive as enumerated from the OS, before filtering. Test seam.</summary>
+	internal readonly record struct RawDrive(
+		string RootPath,
+		string VolumeLabel,
+		string DriveType,
+		bool IsReady,
+		long TotalSize,
+		long AvailableFreeSpace);
+
+	/// <summary>A place the user can jump to in the picker.</summary>
+	internal readonly record struct PlaceEntry(
+		string Path,
+		string DisplayName,
+		string Detail,
+		string Icon,
+		bool IsCurrent);
+
+	// Linux virtual / pseudo filesystems and noisy mount roots to hide.
+	// Mirrors the cxfiles FileSystemService blacklist.
+	private static readonly string[] VirtualFsRoots =
+	{
+		"/proc", "/sys", "/dev", "/run", "/snap",
+		"/var/lib/docker", "/var/lib/containers", "/var/lib/lxcfs"
+	};
+
+	/// <summary>Production entry point: enumerates the real drive table.</summary>
+	public static IReadOnlyList<PlaceEntry> GetPlaces(string? currentPath)
+		=> GetPlaces(
+			currentPath,
+			EnumerateRealDrives(),
+			OperatingSystem.IsWindows(),
+			SafeHome());
+
+	/// <summary>Test seam: filters an injected drive list.</summary>
+	internal static IReadOnlyList<PlaceEntry> GetPlaces(
+		string? currentPath,
+		IEnumerable<RawDrive> drives,
+		bool isWindows,
+		string? homePath)
+	{
+		var kept = new List<RawDrive>();
+		var seenRoots = new HashSet<string>(StringComparer.Ordinal);
+		foreach (var d in drives)
+		{
+			if (!d.IsReady) continue;
+			if (!isWindows && !ShouldShowDrive(d)) continue;
+			// The OS can report the same mount more than once (e.g. network
+			// shares appear twice in DriveInfo.GetDrives()). Keep the first.
+			if (!seenRoots.Add(d.RootPath)) continue;
+			kept.Add(d);
+		}
+
+		string normalizedCurrent = NormalizeForMatch(currentPath);
+		string? bestRoot = LongestPrefixRoot(normalizedCurrent, kept.Select(k => k.RootPath));
+
+		var result = new List<PlaceEntry>();
+		foreach (var d in kept)
+		{
+			result.Add(new PlaceEntry(
+				Path: d.RootPath,
+				DisplayName: d.RootPath,
+				Detail: BuildDetail(d),
+				Icon: IconFor(d.DriveType),
+				IsCurrent: string.Equals(d.RootPath, bestRoot, StringComparison.Ordinal)));
+		}
+
+		// Synthetic Home entry on all platforms.
+		if (!string.IsNullOrEmpty(homePath))
+		{
+			bool homeIsCurrent = bestRoot == null
+				&& normalizedCurrent.StartsWith(NormalizeForMatch(homePath), StringComparison.Ordinal);
+			result.Add(new PlaceEntry(homePath!, "Home", homePath!, "⌂", homeIsCurrent));
+		}
+
+		return result;
+	}
+
+	private static bool ShouldShowDrive(RawDrive d)
+	{
+		var path = d.RootPath;
+		if (path == "/") return true;
+		if (path == "/home" || path == "/home/") return true;
+		if (IsBlacklistedVirtualFs(path)) return false;
+		if (path.StartsWith("/boot", StringComparison.Ordinal)) return false;
+		if (path.StartsWith("/media/", StringComparison.Ordinal)) return true;
+		if (path.StartsWith("/mnt/", StringComparison.Ordinal)) return true;
+		if (path == "/mnt") return true;
+		if (d.DriveType == "Network") return true;
+		if (d.DriveType == "Removable") return true;
+		if (d.DriveType == "CDRom") return true;
+		return false;
+	}
+
+	private static bool IsBlacklistedVirtualFs(string fullPath)
+	{
+		foreach (var v in VirtualFsRoots)
+		{
+			if (fullPath == v) return true;
+			if (fullPath.Length > v.Length &&
+				fullPath.StartsWith(v, StringComparison.Ordinal) &&
+				(fullPath[v.Length] == '/' || fullPath[v.Length] == Path.DirectorySeparatorChar))
+				return true;
+		}
+		return false;
+	}
+
+	private static string IconFor(string driveType) => driveType switch
+	{
+		"Network" => "🌐",
+		"CDRom" => "💿",
+		"Removable" => "🔌",
+		_ => "💾"
+	};
+
+	private static string BuildDetail(RawDrive d)
+	{
+		// Ignore labels that merely repeat the mount path (common on Linux,
+		// where VolumeLabel is often the root path itself).
+		var hasUsefulLabel = !string.IsNullOrWhiteSpace(d.VolumeLabel)
+			&& !string.Equals(d.VolumeLabel, d.RootPath, StringComparison.Ordinal);
+		var label = hasUsefulLabel ? d.VolumeLabel : d.DriveType;
+		if (d.TotalSize > 0)
+			return $"{label} · {FormatSize(d.AvailableFreeSpace)} free";
+		return label;
+	}
+
+	private static string FormatSize(long bytes) => bytes switch
+	{
+		< 1024 => $"{bytes} B",
+		< 1024 * 1024 => $"{bytes / 1024.0:F1} KB",
+		< 1024L * 1024 * 1024 => $"{bytes / (1024.0 * 1024):F1} MB",
+		_ => $"{bytes / (1024.0 * 1024 * 1024):F1} GB"
+	};
+
+	private static string NormalizeForMatch(string? path)
+	{
+		if (string.IsNullOrEmpty(path)) return "";
+		try { return Path.TrimEndingDirectorySeparator(Path.GetFullPath(path)); }
+		catch { return path; }
+	}
+
+	private static string? LongestPrefixRoot(string normalizedCurrent, IEnumerable<string> roots)
+	{
+		string? best = null;
+		int bestLen = -1;
+		foreach (var root in roots)
+		{
+			var r = NormalizeForMatch(root);
+			bool match = normalizedCurrent == r
+				|| normalizedCurrent.StartsWith(
+					r.EndsWith(Path.DirectorySeparatorChar) ? r : r + Path.DirectorySeparatorChar,
+					StringComparison.Ordinal);
+			if (match && r.Length > bestLen)
+			{
+				best = root;
+				bestLen = r.Length;
+			}
+		}
+		return best;
+	}
+
+	private static string? SafeHome()
+	{
+		try
+		{
+			var h = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+			return string.IsNullOrEmpty(h) ? null : h;
+		}
+		catch { return null; }
+	}
+
+	private static IEnumerable<RawDrive> EnumerateRealDrives()
+	{
+		DriveInfo[] drives;
+		try { drives = DriveInfo.GetDrives(); }
+		catch { yield break; }
+
+		foreach (var d in drives)
+		{
+			RawDrive raw;
+			try
+			{
+				bool ready = d.IsReady;
+				raw = new RawDrive(
+					d.RootDirectory.FullName,
+					ready ? SafeLabel(d) : "",
+					d.DriveType.ToString(),
+					ready,
+					ready ? SafeTotal(d) : 0,
+					ready ? SafeFree(d) : 0);
+			}
+			catch { continue; }
+			yield return raw;
+		}
+	}
+
+	private static string SafeLabel(DriveInfo d) { try { return d.VolumeLabel ?? ""; } catch { return ""; } }
+	private static long SafeTotal(DriveInfo d) { try { return d.TotalSize; } catch { return 0; } }
+	private static long SafeFree(DriveInfo d) { try { return d.AvailableFreeSpace; } catch { return 0; } }
+
+	/// <summary>
+	/// Splits a path into its drive/mount segment (rendered as the chip) and the
+	/// remainder. Purely lexical — does not consult the live mount table.
+	/// Windows: "C:\Users" -> ("C:", "\Users").
+	/// Linux:   "/media/usb/p" -> ("/media/usb", "/p");  "/home/n" -> ("/", "home/n").
+	/// </summary>
+	internal static (string Segment, string Remainder) SplitDriveSegment(string path)
+	{
+		if (string.IsNullOrEmpty(path)) return ("", "");
+
+		// Windows-style "X:" prefix.
+		if (path.Length >= 2 && path[1] == ':')
+			return (path.Substring(0, 2), path.Substring(2));
+
+		if (!path.StartsWith("/", StringComparison.Ordinal))
+			return ("", path);
+
+		// Linux: treat /media/<x> and /mnt/<x> as a two-segment mount chip.
+		foreach (var prefix in new[] { "/media/", "/mnt/" })
+		{
+			if (path.StartsWith(prefix, StringComparison.Ordinal))
+			{
+				int next = path.IndexOf('/', prefix.Length);
+				if (next < 0) return (path, "");
+				return (path.Substring(0, next), path.Substring(next));
+			}
+		}
+
+		// Everything else under "/" -> root is the chip.
+		return ("/", path.Substring(1));
+	}
+
+	/// <summary>
+	/// Builds the markup for the clickable drive chip with the embedded
+	/// "(Ctrl+D)" hint, e.g. "[black on deepskyblue1] 💾 C: (Ctrl+D) [/]".
+	/// </summary>
+	internal static string BuildChipMarkup(string driveSegment)
+	{
+		var safe = driveSegment.Replace("[", "[[").Replace("]", "]]");
+		return $"[black on deepskyblue1] 💾 {safe} (Ctrl+D) [/]";
+	}
+}

--- a/SharpConsoleUI/Dialogs/FileDialogs.cs
+++ b/SharpConsoleUI/Dialogs/FileDialogs.cs
@@ -70,6 +70,16 @@ public static class FileDialogs
 		if (!Directory.Exists(currentPath))
 			currentPath = Environment.CurrentDirectory;
 
+		// Builds the path line with a clickable drive chip + (Ctrl+D) hint.
+		string BuildPathMarkup(string path)
+		{
+			var (seg, rest) = DrivePlaces.SplitDriveSegment(path);
+			var restSafe = rest.Replace("[", "[[").Replace("]", "]]");
+			if (restSafe.Length > 50)
+				restSafe = "..." + restSafe.Substring(restSafe.Length - 47);
+			return $"{DrivePlaces.BuildChipMarkup(seg)}[white]{restSafe}[/]";
+		}
+
 		// Create modal window
 		var builder = new WindowBuilder(windowSystem)
 			.WithTitle(title)
@@ -86,9 +96,9 @@ public static class FileDialogs
 
 		var modal = builder.Build();
 
-		// Current path display
+		// Current path display with clickable drive chip
 		var pathDisplay = Ctl.Markup()
-			.AddLine($"[grey50]Path:[/] [white]{EscapeMarkup(currentPath)}[/]")
+			.AddLine(BuildPathMarkup(currentPath))
 			.WithAlignment(HorizontalAlignment.Left)
 			.WithMargin(1, 0, 1, 0)
 			.WithName("PathDisplay")
@@ -171,7 +181,7 @@ public static class FileDialogs
 			var pathCtrl = modal.FindControl<MarkupControl>("PathDisplay");
 			if (pathCtrl != null)
 			{
-				pathCtrl.Text = $"[grey50]Path:[/] [white]{EscapeMarkup(currentPath)}[/]";
+				pathCtrl.Text = BuildPathMarkup(currentPath);
 			}
 		}
 
@@ -250,23 +260,71 @@ public static class FileDialogs
 
 		// Footer with instructions
 		var instructions = foldersOnly
-			? "[grey70]Enter: Select Folder  •  Backspace: Go Up  •  Escape: Cancel[/]"
-			: "[grey70]Enter: Select  •  Backspace: Go Up  •  Escape: Cancel[/]";
+			? "[grey70]Enter: Select Folder  •  Backspace: Go Up  •  Ctrl+D: Places  •  Escape: Cancel[/]"
+			: "[grey70]Enter: Select  •  Backspace: Go Up  •  Ctrl+D: Places  •  Escape: Cancel[/]";
 		modal.AddControl(Ctl.Markup()
 			.AddLine(instructions)
 			.WithAlignment(HorizontalAlignment.Center)
 			.WithMargin(0, 0, 0, 0)
+			.WithName("FooterHint")
 			.StickyBottom()
 			.Build());
+
+		string BrowsingFooter = instructions;
 
 		// Initial population
 		PopulateFolderList(currentPath);
 		if (!foldersOnly)
 			PopulateFileList(currentPath);
 
+		// "Places" mode: the left folder list is temporarily replaced with drives/mounts.
+		bool inPlacesMode = false;
+
+		void EnterPlacesMode()
+		{
+			inPlacesMode = true;
+			folderList.ClearItems();
+			fileList?.ClearItems();
+			var places = DrivePlaces.GetPlaces(currentPath);
+			int currentIndex = 0;
+			for (int i = 0; i < places.Count; i++)
+			{
+				var pl = places[i];
+				var marker = pl.IsCurrent ? "[grey50]●[/] " : "  ";
+				folderList.AddItem(new ListItem(
+					$"{marker}{pl.Icon} {EscapeMarkup(pl.DisplayName)} [grey50]{EscapeMarkup(pl.Detail)}[/]")
+				{ Tag = "PLACE:" + pl.Path });
+				if (pl.IsCurrent) currentIndex = i;
+			}
+			folderList.SelectedIndex = currentIndex;
+
+			var footer = modal.FindControl<MarkupControl>("FooterHint");
+			if (footer != null)
+				footer.Text = "[grey70]Enter: Go to location  •  Esc: Back to browsing[/]";
+		}
+
+		void ExitPlacesMode(string path)
+		{
+			inPlacesMode = false;
+			PopulateFolderList(path);
+			if (!foldersOnly)
+				PopulateFileList(path);
+			var footer = modal.FindControl<MarkupControl>("FooterHint");
+			if (footer != null)
+				footer.Text = BrowsingFooter;
+		}
+
 		// Handle folder list activation (navigate into folder)
 		folderList.ItemActivated += (sender, item) =>
 		{
+			if (inPlacesMode && item?.Tag is string placeTag && placeTag.StartsWith("PLACE:", StringComparison.Ordinal))
+			{
+				var placePath = placeTag.Substring("PLACE:".Length);
+				if (Directory.Exists(placePath))
+					ExitPlacesMode(placePath);
+				return;
+			}
+
 			if (item?.Tag is string folderPath && Directory.Exists(folderPath))
 			{
 				PopulateFolderList(folderPath);
@@ -279,6 +337,28 @@ public static class FileDialogs
 				selectedPath = selectedFolder;
 				modal.Close();
 			}
+		};
+
+		// Ctrl+D / Places-mode Esc handled before the focused list sees the key.
+		modal.PreviewKeyPressed += (sender, e) =>
+		{
+			if (e.KeyInfo.Key == ConsoleKey.D &&
+				(e.KeyInfo.Modifiers & ConsoleModifiers.Control) != 0)
+			{
+				if (!inPlacesMode) EnterPlacesMode();
+				e.Handled = true;
+			}
+			else if (e.KeyInfo.Key == ConsoleKey.Escape && inPlacesMode)
+			{
+				ExitPlacesMode(currentPath);
+				e.Handled = true;
+			}
+		};
+
+		// Clicking the path line opens Places.
+		pathDisplay.MouseClick += (sender, e) =>
+		{
+			if (!inPlacesMode) EnterPlacesMode();
 		};
 
 		// Handle file list activation (select file)
@@ -297,6 +377,13 @@ public static class FileDialogs
 		// Handle keyboard navigation
 		modal.KeyPressed += (sender, e) =>
 		{
+			if (inPlacesMode)
+			{
+				// In Places mode only the list (Enter to activate) and the
+				// PreviewKeyPressed Esc handler are active.
+				return;
+			}
+
 			if (e.KeyInfo.Key == ConsoleKey.Escape)
 			{
 				selectedPath = null;
@@ -355,6 +442,16 @@ public static class FileDialogs
 		if (!Directory.Exists(currentPath))
 			currentPath = Environment.CurrentDirectory;
 
+		// Builds the path line with a clickable drive chip + (Ctrl+D) hint.
+		string BuildPathMarkup(string path)
+		{
+			var (seg, rest) = DrivePlaces.SplitDriveSegment(path);
+			var restSafe = rest.Replace("[", "[[").Replace("]", "]]");
+			if (restSafe.Length > 50)
+				restSafe = "..." + restSafe.Substring(restSafe.Length - 47);
+			return $"{DrivePlaces.BuildChipMarkup(seg)}[white]{restSafe}[/]";
+		}
+
 		// Create modal window
 		var builder = new WindowBuilder(windowSystem)
 			.WithTitle(title)
@@ -371,9 +468,9 @@ public static class FileDialogs
 
 		var modal = builder.Build();
 
-		// Current path display
+		// Current path display with clickable drive chip
 		var pathDisplay = Ctl.Markup()
-			.AddLine($"[grey50]Folder:[/] [white]{EscapeMarkup(currentPath)}[/]")
+			.AddLine(BuildPathMarkup(currentPath))
 			.WithAlignment(HorizontalAlignment.Left)
 			.WithMargin(1, 0, 1, 0)
 			.WithName("PathDisplay")
@@ -452,7 +549,7 @@ public static class FileDialogs
 			var pathCtrl = modal.FindControl<MarkupControl>("PathDisplay");
 			if (pathCtrl != null)
 			{
-				pathCtrl.Text = $"[grey50]Folder:[/] [white]{EscapeMarkup(currentPath)}[/]";
+				pathCtrl.Text = BuildPathMarkup(currentPath);
 			}
 		}
 
@@ -534,10 +631,12 @@ public static class FileDialogs
 			.Build());
 
 		// Footer with instructions
+		const string SaveBrowsingFooter = "[grey70]Enter: Save  •  Backspace: Go Up  •  Ctrl+D: Places  •  Escape: Cancel[/]";
 		modal.AddControl(Ctl.Markup()
-			.AddLine("[grey70]Enter: Save  •  Backspace: Go Up  •  Escape: Cancel[/]")
+			.AddLine(SaveBrowsingFooter)
 			.WithAlignment(HorizontalAlignment.Center)
 			.WithMargin(0, 0, 0, 0)
+			.WithName("FooterHint")
 			.StickyBottom()
 			.Build());
 
@@ -545,14 +644,80 @@ public static class FileDialogs
 		PopulateFolderList(currentPath);
 		PopulateFileList(currentPath);
 
+		// "Places" mode: the left folder list is temporarily replaced with drives/mounts.
+		bool inPlacesMode = false;
+
+		void EnterPlacesMode()
+		{
+			inPlacesMode = true;
+			folderList.ClearItems();
+			fileList.ClearItems();
+			var places = DrivePlaces.GetPlaces(currentPath);
+			int currentIndex = 0;
+			for (int i = 0; i < places.Count; i++)
+			{
+				var pl = places[i];
+				var marker = pl.IsCurrent ? "[grey50]●[/] " : "  ";
+				folderList.AddItem(new ListItem(
+					$"{marker}{pl.Icon} {EscapeMarkup(pl.DisplayName)} [grey50]{EscapeMarkup(pl.Detail)}[/]")
+				{ Tag = "PLACE:" + pl.Path });
+				if (pl.IsCurrent) currentIndex = i;
+			}
+			folderList.SelectedIndex = currentIndex;
+
+			var footer = modal.FindControl<MarkupControl>("FooterHint");
+			if (footer != null)
+				footer.Text = "[grey70]Enter: Go to location  •  Esc: Back to browsing[/]";
+		}
+
+		void ExitPlacesMode(string path)
+		{
+			inPlacesMode = false;
+			PopulateFolderList(path);
+			PopulateFileList(path);
+			var footer = modal.FindControl<MarkupControl>("FooterHint");
+			if (footer != null)
+				footer.Text = SaveBrowsingFooter;
+		}
+
 		// Handle folder list activation (navigate into folder)
 		folderList.ItemActivated += (sender, item) =>
 		{
+			if (inPlacesMode && item?.Tag is string placeTag && placeTag.StartsWith("PLACE:", StringComparison.Ordinal))
+			{
+				var placePath = placeTag.Substring("PLACE:".Length);
+				if (Directory.Exists(placePath))
+					ExitPlacesMode(placePath);
+				return;
+			}
+
 			if (item?.Tag is string folderPath && Directory.Exists(folderPath))
 			{
 				PopulateFolderList(folderPath);
 				PopulateFileList(folderPath);
 			}
+		};
+
+		// Ctrl+D / Places-mode Esc handled before the focused filename field sees the key.
+		modal.PreviewKeyPressed += (sender, e) =>
+		{
+			if (e.KeyInfo.Key == ConsoleKey.D &&
+				(e.KeyInfo.Modifiers & ConsoleModifiers.Control) != 0)
+			{
+				if (!inPlacesMode) EnterPlacesMode();
+				e.Handled = true;
+			}
+			else if (e.KeyInfo.Key == ConsoleKey.Escape && inPlacesMode)
+			{
+				ExitPlacesMode(currentPath);
+				e.Handled = true;
+			}
+		};
+
+		// Clicking the path line opens Places.
+		pathDisplay.MouseClick += (sender, e) =>
+		{
+			if (!inPlacesMode) EnterPlacesMode();
 		};
 
 		// Handle file list activation (copy filename to input)
@@ -580,6 +745,13 @@ public static class FileDialogs
 		// Handle keyboard navigation
 		modal.KeyPressed += (sender, e) =>
 		{
+			if (inPlacesMode)
+			{
+				// In Places mode only the list (Enter to activate) and the
+				// PreviewKeyPressed Esc handler are active.
+				return;
+			}
+
 			if (e.KeyInfo.Key == ConsoleKey.Escape)
 			{
 				selectedPath = null;

--- a/SharpConsoleUI/Dialogs/FolderPickerDialog.cs
+++ b/SharpConsoleUI/Dialogs/FolderPickerDialog.cs
@@ -42,6 +42,17 @@ public static class FolderPickerDialog
 		if (!Directory.Exists(currentPath))
 			currentPath = Environment.CurrentDirectory;
 
+		// Builds the path line with a clickable drive chip + (Ctrl+D) hint.
+		string BuildPathMarkup(string path)
+		{
+			var (seg, rest) = DrivePlaces.SplitDriveSegment(path);
+			var restSafe = rest.Replace("[", "[[").Replace("]", "]]");
+			// Truncate the remainder if very long, keeping the chip intact.
+			if (restSafe.Length > 50)
+				restSafe = "..." + restSafe.Substring(restSafe.Length - 47);
+			return $"{DrivePlaces.BuildChipMarkup(seg)}[white]{restSafe}[/]";
+		}
+
 		// Create modal window
 		var builder = new WindowBuilder(windowSystem)
 			.WithTitle(title ?? "Select Folder")
@@ -58,9 +69,9 @@ public static class FolderPickerDialog
 
 		var modal = builder.Build();
 
-		// Breadcrumb path display with individual path segments
+		// Breadcrumb path display with clickable drive chip
 		var pathDisplay = Ctl.Markup()
-			.AddLine($"[grey50]Current:[/] [white]{EscapeMarkup(currentPath)}[/]")
+			.AddLine(BuildPathMarkup(currentPath))
 			.WithAlignment(HorizontalAlignment.Left)
 			.WithMargin(1, 0, 1, 0)
 			.WithName("PathDisplay")
@@ -111,9 +122,10 @@ public static class FolderPickerDialog
 
 		// Footer with keyboard shortcuts
 		modal.AddControl(Ctl.Markup()
-			.AddLine("[grey70]Enter: Open/Select  •  Backspace: Go Up  •  Escape: Cancel[/]")
+			.AddLine("[grey70]Enter: Open/Select  •  Backspace: Go Up  •  Ctrl+D: Places  •  Escape: Cancel[/]")
 			.WithAlignment(HorizontalAlignment.Center)
 			.WithMargin(0, 0, 0, 0)
+			.WithName("FooterHint")
 			.StickyBottom()
 			.Build());
 
@@ -192,24 +204,91 @@ public static class FolderPickerDialog
 			var pathCtrl = modal.FindControl<MarkupControl>("PathDisplay");
 			if (pathCtrl != null)
 			{
-				// Truncate path if too long
-				var displayPath = currentPath;
-				if (displayPath.Length > 60)
-				{
-					displayPath = "..." + displayPath.Substring(displayPath.Length - 57);
-				}
-				pathCtrl.Text = $"[grey50]Current:[/] [white]{EscapeMarkup(displayPath)}[/]";
+				pathCtrl.Text = BuildPathMarkup(currentPath);
 			}
+		}
+
+		// "Places" mode: the folder list is temporarily replaced with drives/mounts.
+		bool inPlacesMode = false;
+
+		const string BrowsingFooter = "[grey70]Enter: Open/Select  •  Backspace: Go Up  •  Ctrl+D: Places  •  Escape: Cancel[/]";
+
+		void EnterPlacesMode()
+		{
+			inPlacesMode = true;
+			folderList.ClearItems();
+			var places = DrivePlaces.GetPlaces(currentPath);
+			int currentIndex = 0;
+			for (int i = 0; i < places.Count; i++)
+			{
+				var pl = places[i];
+				var marker = pl.IsCurrent ? "[grey50]●[/] " : "  ";
+				folderList.AddItem(new ListItem(
+					$"{marker}{pl.Icon} {EscapeMarkup(pl.DisplayName)} [grey50]{EscapeMarkup(pl.Detail)}[/]")
+				{
+					Tag = pl.Path
+				});
+				if (pl.IsCurrent) currentIndex = i;
+			}
+			folderList.SelectedIndex = currentIndex;
+
+			var footer = modal.FindControl<MarkupControl>("FooterHint");
+			if (footer != null)
+				footer.Text = "[grey70]Enter: Go to location  •  Esc: Back to browsing[/]";
+		}
+
+		void ExitPlacesMode()
+		{
+			inPlacesMode = false;
+			PopulateFolderList(currentPath);
+			var footer = modal.FindControl<MarkupControl>("FooterHint");
+			if (footer != null)
+				footer.Text = BrowsingFooter;
 		}
 
 		// Handle folder list activation (double-click or Enter on focused item)
 		folderList.ItemActivated += (sender, item) =>
 		{
+			if (inPlacesMode)
+			{
+				if (item?.Tag is string placePath && Directory.Exists(placePath))
+				{
+					inPlacesMode = false;
+					PopulateFolderList(placePath);
+					var footer = modal.FindControl<MarkupControl>("FooterHint");
+					if (footer != null)
+						footer.Text = BrowsingFooter;
+				}
+				return;
+			}
+
 			if (item?.Tag is FolderEntry entry && Directory.Exists(entry.Path))
 			{
 				// Navigate into the selected folder
 				PopulateFolderList(entry.Path);
 			}
+		};
+
+		// Ctrl+D / Places-mode Esc handled before the focused list sees the key.
+		modal.PreviewKeyPressed += (sender, e) =>
+		{
+			if (e.KeyInfo.Key == ConsoleKey.D &&
+				(e.KeyInfo.Modifiers & ConsoleModifiers.Control) != 0)
+			{
+				if (!inPlacesMode) EnterPlacesMode();
+				e.Handled = true;
+			}
+			else if (e.KeyInfo.Key == ConsoleKey.Escape && inPlacesMode)
+			{
+				ExitPlacesMode();
+				e.Handled = true; // do NOT let the dialog's Escape=cancel fire
+			}
+		};
+
+		// Clicking the path line opens Places.
+		pathDisplay.MouseClick += (sender, e) =>
+		{
+			if (!inPlacesMode) EnterPlacesMode();
 		};
 
 		// Handle "Select This Folder" button
@@ -229,6 +308,13 @@ public static class FolderPickerDialog
 		// Handle keyboard navigation
 		modal.KeyPressed += (sender, e) =>
 		{
+			if (inPlacesMode)
+			{
+				// In Places mode only the list (Enter to activate) and the
+				// PreviewKeyPressed Esc handler are active.
+				return;
+			}
+
 			if (e.KeyInfo.Key == ConsoleKey.Escape)
 			{
 				selectedPath = null;


### PR DESCRIPTION
## Summary
Adds a cross-platform **"Places"** drive/location picker to the folder picker, file picker, and save dialogs, addressing #26 (switching drives / mounts from within the pickers).

- **`DrivePlaces`** (new internal helper) — OS-aware enumeration. Windows lists all ready drives; Linux/macOS lists `/`, `/media`/`/mnt` mounts, network/removable/CD volumes, plus a synthetic **Home**, filtering out virtual filesystems (`/proc`, `/sys`, `/snap/*`, `/var/lib/docker/*`, `/boot/*`). Dedupes mount roots the OS reports more than once.
- **Clickable drive chip** in the path line — `💾 <drive> (Ctrl+D)` with the shortcut embedded in the chip.
- **Ctrl+D** opens an inline "Places" list takeover (current location marked); **Enter** jumps to a place, **Esc** returns to browsing without closing the dialog.
- Ctrl+D is handled via `PreviewKeyPressed`, so it works even while the save dialog's filename field has focus.
- **No public API changes** — the three `Show*Async` signatures and behaviors are unchanged; the affordance is additive.

## Test Plan
- [x] `DrivePlaces` unit tests: Windows/Linux filtering, virtual-fs exclusion, dedup, Home entry, current-place longest-prefix match, path-segment split.
- [x] CI-safe real-enumeration smoke test (asserts invariants only — non-empty, root present, blacklist excluded — since CI mount tables are non-deterministic).
- [x] Headless behavioral tests across all three dialogs: Ctrl+D enters Places mode, Enter navigates + exits, Esc returns to browsing without closing.
- [x] Manual visual check in a real terminal: chip renders, Places list shows mounts + Home with current marked.
- [x] Full suite green (3246 passing); Release build clean.