### PR TITLE
Modify the `AppendText` method of `MarkupControl` to align its behavior with `Console.Append()`.

### DIFF
--- a/SharpConsoleUI.Tests/Controls/MarkupBuilderAddTextTests.cs
+++ b/SharpConsoleUI.Tests/Controls/MarkupBuilderAddTextTests.cs
@@ -1,0 +1,76 @@
+// -----------------------------------------------------------------------
+// ConsoleEx - A simple console window system for .NET Core
+//
+// Author: Nikolaos Protopapas
+// Email: nikolaos.protopapas@gmail.com
+// License: MIT
+// -----------------------------------------------------------------------
+
+using SharpConsoleUI.Controls;
+using Xunit;
+
+namespace SharpConsoleUI.Tests.Controls;
+
+/// <summary>
+/// Tests for <see cref="Builders.MarkupBuilder.AddText"/>, which appends inline (Console.Write-style)
+/// — the first segment joins the current last line, and a new line begins only at each embedded \n.
+/// </summary>
+public class MarkupBuilderAddTextTests
+{
+	[Fact]
+	public void AddText_JoinsOntoPreviousAddText()
+	{
+		var control = MarkupControl.Create()
+			.AddText("Hello, ")
+			.AddText("world")
+			.Build();
+
+		Assert.Equal("Hello, world", control.Text);
+	}
+
+	[Fact]
+	public void AddText_NewlineStartsNewLine()
+	{
+		var control = MarkupControl.Create()
+			.AddText("a\nb")
+			.Build();
+
+		Assert.Equal("a\nb", control.Text);
+	}
+
+	[Fact]
+	public void AddText_LeadingNewlines_StartNewLines()
+	{
+		// "\n\ntail" after "head": empty first segment joins "head" (no-op), then a blank line, then "tail".
+		var control = MarkupControl.Create()
+			.AddLine("head")
+			.AddText("\n\ntail")
+			.Build();
+
+		Assert.Equal("head\n\ntail", control.Text);
+	}
+
+	[Fact]
+	public void AddText_AfterAddLine_JoinsOntoThatLine()
+	{
+		var control = MarkupControl.Create()
+			.AddLine("line")
+			.AddText(" tail")
+			.Build();
+
+		Assert.Equal("line tail", control.Text);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	public void AddText_NullOrEmpty_IsNoOp(string? text)
+	{
+		var control = MarkupControl.Create()
+			.AddLine("x")
+			.AddText(text!)
+			.Build();
+
+		Assert.Equal("x", control.Text);
+	}
+}

--- a/SharpConsoleUI.Tests/Controls/MarkupControlCopyTests.cs
+++ b/SharpConsoleUI.Tests/Controls/MarkupControlCopyTests.cs
@@ -67,6 +67,76 @@ public class MarkupControlCopyTests
 	}
 
 	[Fact]
+	public void AppendText_DefaultInlineIsFalse_StartsNewLine()
+	{
+		// Explicit default arg must match the implicit default (line-per-call).
+		var c = new MarkupControl(new List<string> { "x" });
+		c.AppendText("y\nz", inline: false);
+		Assert.Equal("x\ny\nz", c.Text);
+	}
+
+	[Fact]
+	public void AppendText_Inline_JoinsFirstSegmentOntoCurrentLine()
+	{
+		var c = new MarkupControl(new List<string> { "x" });
+		c.AppendText("y\nz", inline: true);
+		Assert.Equal("xy\nz", c.Text);
+	}
+
+	[Fact]
+	public void AppendText_Inline_LeadingNewlineStartsNewLine()
+	{
+		var c = new MarkupControl(new List<string> { "x" });
+		c.AppendText("\ny", inline: true);
+		Assert.Equal("x\ny", c.Text);
+	}
+
+	[Fact]
+	public void AppendText_Inline_MultipleLeadingNewlines_InsertBlankLines()
+	{
+		// "\n\ny" -> first (empty) segment joins "x" (no-op), then a blank line, then "y".
+		var c = new MarkupControl(new List<string> { "x" });
+		c.AppendText("\n\ny", inline: true);
+		Assert.Equal("x\n\ny", c.Text);
+	}
+
+	[Fact]
+	public void AppendInline_StringIsOnlyNewlines_AddsBlankLines()
+	{
+		// Inline-appending pure newlines just opens new (blank) lines below the current one.
+		var c = new MarkupControl(new List<string> { "x" });
+		c.AppendInline("\n\n");
+		Assert.Equal("x\n\n", c.Text);
+	}
+
+	[Fact]
+	public void AppendInline_JoinsFirstSegmentOntoCurrentLine()
+	{
+		var c = new MarkupControl(new List<string> { "x" });
+		c.AppendInline("y\nz");
+		Assert.Equal("xy\nz", c.Text);
+	}
+
+	[Fact]
+	public void AppendInline_OnEmptyContent_AddsAsFirstLine()
+	{
+		var c = new MarkupControl(new List<string>());
+		c.AppendInline("hello");
+		Assert.Equal("hello", c.Text);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	public void AppendText_NullOrEmpty_IsNoOp(string? text)
+	{
+		var c = new MarkupControl(new List<string> { "x" });
+		c.AppendText(text!);
+		c.AppendText(text!, inline: true);
+		Assert.Equal("x", c.Text);
+	}
+
+	[Fact]
 	public void Append_ClearsStaleSelection()
 	{
 		var c = new MarkupControl(new List<string> { "hello world" }) { EnableSelection = true };

--- a/SharpConsoleUI/Builders/MarkupBuilder.cs
+++ b/SharpConsoleUI/Builders/MarkupBuilder.cs
@@ -6,6 +6,7 @@
 // License: MIT
 // -----------------------------------------------------------------------
 
+using System.Text;
 using SharpConsoleUI.Controls;
 using SharpConsoleUI.DataBinding;
 using SharpConsoleUI.Events;
@@ -49,6 +50,48 @@ public sealed class MarkupBuilder : IControlBuilder<MarkupControl>
 	public MarkupBuilder AddLine(string markup)
 	{
 		_lines.Add(markup ?? string.Empty);
+		return this;
+	}
+
+	/// <summary>
+	/// Adds string of markup text
+	/// </summary>
+	/// <param name="markup">The markup text</param>
+	/// <returns>The builder for chaining</returns>
+	public MarkupBuilder AddText(string markup)
+	{
+		// arg check
+		if (markup == null || string.Empty.Equals(markup)) return this;
+
+		// Ensure at least one line exists as the current line.
+		if (_lines.Count == 0)
+			_lines.Add(string.Empty);
+
+		StringBuilder charPool = new StringBuilder();
+
+		foreach (char c in markup)
+		{
+			if (c == '\n')
+			{
+				// Append all previously accumulated characters to the current line.
+				_lines[^1] += charPool.ToString();
+
+				// Clear the accumulated characters.
+				charPool.Clear();
+
+				// new line
+				_lines.Add(string.Empty);
+			}
+			else
+			{
+				charPool.Append(c);
+			}
+		}
+
+		// Append the last segment of characters to the current line.
+		if (charPool.Length > 0)
+			_lines[^1] += charPool.ToString();
+
 		return this;
 	}
 

--- a/SharpConsoleUI/Builders/MarkupBuilder.cs
+++ b/SharpConsoleUI/Builders/MarkupBuilder.cs
@@ -6,7 +6,6 @@
 // License: MIT
 // -----------------------------------------------------------------------
 
-using System.Text;
 using SharpConsoleUI.Controls;
 using SharpConsoleUI.DataBinding;
 using SharpConsoleUI.Events;
@@ -54,43 +53,26 @@ public sealed class MarkupBuilder : IControlBuilder<MarkupControl>
 	}
 
 	/// <summary>
-	/// Adds string of markup text
+	/// Appends markup text to the current last line (<c>Console.Write</c>-style): the first segment is
+	/// joined onto the line added so far, and a new line begins only at each embedded <c>\n</c>. Use
+	/// <see cref="AddLine"/> when you want each call to start on its own line.
 	/// </summary>
 	/// <param name="markup">The markup text</param>
 	/// <returns>The builder for chaining</returns>
 	public MarkupBuilder AddText(string markup)
 	{
-		// arg check
-		if (markup == null || string.Empty.Equals(markup)) return this;
+		if (string.IsNullOrEmpty(markup)) return this;
 
-		// Ensure at least one line exists as the current line.
+		var parts = markup.Split('\n');
+
+		// Ensure at least one line exists, then join the first segment onto the current last line.
 		if (_lines.Count == 0)
 			_lines.Add(string.Empty);
+		_lines[^1] += parts[0];
 
-		StringBuilder charPool = new StringBuilder();
-
-		foreach (char c in markup)
-		{
-			if (c == '\n')
-			{
-				// Append all previously accumulated characters to the current line.
-				_lines[^1] += charPool.ToString();
-
-				// Clear the accumulated characters.
-				charPool.Clear();
-
-				// new line
-				_lines.Add(string.Empty);
-			}
-			else
-			{
-				charPool.Append(c);
-			}
-		}
-
-		// Append the last segment of characters to the current line.
-		if (charPool.Length > 0)
-			_lines[^1] += charPool.ToString();
+		// Remaining segments each start a new line.
+		for (int i = 1; i < parts.Length; i++)
+			_lines.Add(parts[i]);
 
 		return this;
 	}

--- a/SharpConsoleUI/Controls/MarkupControl.cs
+++ b/SharpConsoleUI/Controls/MarkupControl.cs
@@ -7,6 +7,7 @@
 // -----------------------------------------------------------------------
 
 using System.Drawing;
+using System.Text;
 using SharpConsoleUI.Core;
 using SharpConsoleUI.Drivers;
 using SharpConsoleUI.Events;
@@ -265,14 +266,52 @@ namespace SharpConsoleUI.Controls
 		/// <param name="text">The text to append. Embedded <c>\n</c> characters start new lines.</param>
 		public void AppendText(string text)
 		{
-			var parts = (text ?? string.Empty).Split('\n');
+			// arg check
+			if (text == null || string.Empty.Equals(text)) return;
+
 			lock (_contentLock)
 			{
-				foreach (var part in parts)
-					_content.Add(part);
+				AppendCore(text);
 			}
+
 			OnContentAppended();
 		}
+
+		private void AppendCore(string text)
+		{
+			// defensive check
+			if (text == null || string.Empty.Equals(text)) return;
+
+			// Ensure at least one line exists as the current line.
+			if (_content.Count == 0)
+				_content.Add(string.Empty);
+
+			StringBuilder charPool = new StringBuilder();
+
+			foreach (char c in text)
+			{
+				if (c == '\n')
+				{
+					// Append all previously accumulated characters to the current line.
+					_content[^1] += charPool.ToString();
+
+					// Clear the accumulated characters.
+					charPool.Clear();
+
+					// new line
+					_content.Add(string.Empty);
+				}
+				else
+				{
+					charPool.Append(c);
+				}
+			}
+
+			// Append the last segment of characters to the current line.
+			if (charPool.Length > 0)
+				_content[^1] += charPool.ToString();
+		}
+
 
 		/// <summary>Shared post-append bookkeeping: any active selection is now stale, so clear it.</summary>
 		private void OnContentAppended()

--- a/SharpConsoleUI/Controls/MarkupControl.cs
+++ b/SharpConsoleUI/Controls/MarkupControl.cs
@@ -7,7 +7,6 @@
 // -----------------------------------------------------------------------
 
 using System.Drawing;
-using System.Text;
 using SharpConsoleUI.Core;
 using SharpConsoleUI.Drivers;
 using SharpConsoleUI.Events;
@@ -264,53 +263,40 @@ namespace SharpConsoleUI.Controls
 		/// Appends text to the content, splitting on newlines into separate lines.
 		/// </summary>
 		/// <param name="text">The text to append. Embedded <c>\n</c> characters start new lines.</param>
-		public void AppendText(string text)
+		/// <param name="inline">
+		/// When <c>false</c> (the default), the appended text starts on a new line — each segment between
+		/// <c>\n</c> characters becomes its own content line. When <c>true</c>, the first segment is joined
+		/// onto the current last line (<c>Console.Write</c>-style), and a new line begins only at each
+		/// embedded <c>\n</c>.
+		/// </param>
+		public void AppendText(string text, bool inline = false)
 		{
-			// arg check
-			if (text == null || string.Empty.Equals(text)) return;
+			if (string.IsNullOrEmpty(text)) return;
 
+			var parts = text.Split('\n');
 			lock (_contentLock)
 			{
-				AppendCore(text);
-			}
+				int startIndex = 0;
+				if (inline && _content.Count > 0)
+				{
+					// Join the first segment onto the current last line; remaining segments are new lines.
+					_content[^1] += parts[0];
+					startIndex = 1;
+				}
 
+				for (int i = startIndex; i < parts.Length; i++)
+					_content.Add(parts[i]);
+			}
 			OnContentAppended();
 		}
 
-		private void AppendCore(string text)
-		{
-			// defensive check
-			if (text == null || string.Empty.Equals(text)) return;
-
-			// Ensure at least one line exists as the current line.
-			if (_content.Count == 0)
-				_content.Add(string.Empty);
-
-			StringBuilder charPool = new StringBuilder();
-
-			foreach (char c in text)
-			{
-				if (c == '\n')
-				{
-					// Append all previously accumulated characters to the current line.
-					_content[^1] += charPool.ToString();
-
-					// Clear the accumulated characters.
-					charPool.Clear();
-
-					// new line
-					_content.Add(string.Empty);
-				}
-				else
-				{
-					charPool.Append(c);
-				}
-			}
-
-			// Append the last segment of characters to the current line.
-			if (charPool.Length > 0)
-				_content[^1] += charPool.ToString();
-		}
+		/// <summary>
+		/// Appends text to the current last line (<c>Console.Write</c>-style), starting new lines only at
+		/// embedded <c>\n</c> characters. Equivalent to <see cref="AppendText(string, bool)"/> with
+		/// <c>inline: true</c>.
+		/// </summary>
+		/// <param name="text">The text to append. Embedded <c>\n</c> characters start new lines.</param>
+		public void AppendInline(string text) => AppendText(text, inline: true);
 
 
 		/// <summary>Shared post-append bookkeeping: any active selection is now stale, so clear it.</summary>


### PR DESCRIPTION
## Summary

<!-- Brief description of the changes -->

Modify the `AppendText` method of `MarkupControl` to align its behavior with `Console.Append()`.

The default behavior of the `AppendText` method should be appending text inline; a new line is only created when encountering `\n`.

## Changes

<!-- List the main changes -->
- change: MarkupControl.AppendText method.
- Add: MarkupBuilder.AddText method.

## Type

- [ ] Bug fix
- [X] New feature
- [X] Enhancement
- [ ] Documentation
- [ ] Refactoring

## Testing

<!-- How did you test these changes? -->
- [ ] Tested with DemoApp
- [ ] Tested with relevant example(s)
- [X] Solution builds without errors
- [ ] All tests pass (`dotnet test SharpConsoleUI.Tests/SharpConsoleUI.Tests.csproj -c Release`)

## Code quality

<!-- See docs/CODE_QUALITY.md -->
- [X] **No breaking changes** to public API (no removed/renamed members or changed signatures/defaults)
- [X] No console output added to library code
- [ ] No magic numbers (literals extracted to `ControlDefaults`/`LayoutDefaults`)
- [ ] UI mutations from background threads are marshalled via `EnqueueOnUIThread`/`InvokeAsync`
- [ ] New source files carry the file-header banner

## Screenshots

<!-- If applicable, add screenshots for UI changes -->
