### PR TITLE
Fix issue #45, which is caused by improper handling of the `'\r'` cha…

### DIFF
--- a/SharpConsoleUI/Builders/MarkupBuilder.cs
+++ b/SharpConsoleUI/Builders/MarkupBuilder.cs
@@ -76,7 +76,19 @@ public sealed class MarkupBuilder : IControlBuilder<MarkupControl>
 	/// <returns>The builder for chaining</returns>
 	public MarkupBuilder AddLine(string markup)
 	{
-		_lines.Add(markup ?? string.Empty);
+		// fix bug: Fix garbled text caused by improper handling of the `\r` character on Windows systems (issue #45)
+		// fix bug: Correct the behavioral logic of the AddLine method to properly handle line breaks within text.
+
+		if (markup == null || string.Empty.Equals(markup))
+		{
+			_lines.Add(string.Empty); // add empty line.
+		}
+		else
+		{
+			// add empty lines and other lines.
+			_lines.AddRange(markup.Split(["\r\n", "\r", "\n"], StringSplitOptions.None)); // fix: handle windows newline char.
+		}
+
 		return this;
 	}
 
@@ -92,7 +104,7 @@ public sealed class MarkupBuilder : IControlBuilder<MarkupControl>
 	{
 		if (string.IsNullOrEmpty(markup)) return this;
 
-		var parts = markup.Split('\n');
+		var parts = markup.Split(["\r\n", "\r", "\n"], StringSplitOptions.None); // fix: handle windows newline char.
 
 		// Ensure at least one line exists, then join the first segment onto the current last line.
 		if (_lines.Count == 0)

--- a/SharpConsoleUI/Builders/MarkupBuilder.cs
+++ b/SharpConsoleUI/Builders/MarkupBuilder.cs
@@ -79,7 +79,7 @@ public sealed class MarkupBuilder : IControlBuilder<MarkupControl>
 		// fix bug: Fix garbled text caused by improper handling of the `\r` character on Windows systems (issue #45)
 		// fix bug: Correct the behavioral logic of the AddLine method to properly handle line breaks within text.
 
-		if (markup == null || string.Empty.Equals(markup))
+		if (string.IsNullOrEmpty(markup))
 		{
 			_lines.Add(string.Empty); // add empty line.
 		}

--- a/SharpConsoleUI/Controls/MarkupControl.cs
+++ b/SharpConsoleUI/Controls/MarkupControl.cs
@@ -113,7 +113,7 @@ namespace SharpConsoleUI.Controls
 			get { lock (_contentLock) { return string.Join("\n", _content); } }
 			set
 			{
-				lock (_contentLock) { _content = value.Split('\n').ToList(); }
+				lock (_contentLock) { _content = value.Split(["\r\n", "\r", "\n"], StringSplitOptions.None).ToList(); } // fix: handle windows newline char.
 				InvalidateLinkCount();
 				OnPropertyChanged();
 				Container?.Invalidate(true);
@@ -253,7 +253,7 @@ namespace SharpConsoleUI.Controls
 			int totalLines = 0;
 			foreach (var line in snapshot)
 			{
-				var subLines = line.Split('\n');
+				var subLines = line.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);  // fix: handle windows newline char.
 				totalLines += subLines.Length;
 			}
 
@@ -329,7 +329,7 @@ namespace SharpConsoleUI.Controls
 		{
 			if (string.IsNullOrEmpty(text)) return;
 
-			var parts = text.Split('\n');
+			var parts = text.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);  // fix: handle windows newline char.
 			lock (_contentLock)
 			{
 				int startIndex = 0;
@@ -492,7 +492,7 @@ namespace SharpConsoleUI.Controls
 				else
 				{
 					// Count explicit newlines
-					var subLines = line.Split('\n');
+					var subLines = line.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);  // fix: handle windows newline char.
 					totalLines += subLines.Length;
 				}
 			}
@@ -576,7 +576,7 @@ namespace SharpConsoleUI.Controls
 					// otherwise emit a U+FFFD replacement glyph (issue #45). The wrap path (ParseLines)
 					// already splits; this keeps the non-wrap path symmetric, and matches how
 					// GetLogicalContentSize counts rows.
-					foreach (var subLine in line.Split('\n'))
+					foreach (var subLine in line.Split(["\r\n", "\r", "\n"], StringSplitOptions.None))  // fix: handle windows newline char.
 					{
 						var cells = Parsing.MarkupParser.Parse(subLine, effectiveFg, effectiveBg, out var lineLinks, mdStyle);
 						renderedCellLines.Add(cells);

--- a/SharpConsoleUI/Parsing/MarkupParser.cs
+++ b/SharpConsoleUI/Parsing/MarkupParser.cs
@@ -316,7 +316,7 @@ namespace SharpConsoleUI.Parsing
 			if (markup.Contains('\n'))
 			{
 				int maxLen = 0;
-				foreach (var line in markup.Split('\n'))
+				foreach (var line in markup.Split(["\r\n", "\r", "\n"], StringSplitOptions.None))  // fix: handle windows newline char.
 				{
 					int lineLen = StripLengthSingleLine(line);
 					if (lineLen > maxLen) maxLen = lineLen;
@@ -667,7 +667,7 @@ namespace SharpConsoleUI.Parsing
 			var result = new List<List<Cell>>();
 
 			// First split on explicit newlines
-			var explicitLines = markup.Split('\n');
+			var explicitLines = markup.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);  // fix: handle windows newline char.
 			foreach (var line in explicitLines)
 			{
 				var cells = Parse(line, defaultFg, defaultBg, out var lineSpans);


### PR DESCRIPTION
…racter.

## Summary

<!-- Brief description of the changes -->

Fix Bug: Fix garbled text caused by improper handling of the `\r` character on Windows systems (issue #45)
Fix Bug: Correct the behavioral logic of the AddLine method to properly handle line breaks within text.

## Changes

<!-- List the main changes -->
- change : MarkupBuilder.cs
- change : MarkupControl.cs
- change : MarkupParser.cs

## Type

- [X] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactoring

## Testing

<!-- How did you test these changes? -->
- [ ] Tested with DemoApp
- [ ] Tested with relevant example(s)
- [X] Solution builds without errors
- [ ] All tests pass (`dotnet test SharpConsoleUI.Tests/SharpConsoleUI.Tests.csproj -c Release`)

## Code quality

<!-- See docs/CODE_QUALITY.md -->
- [X] **No breaking changes** to public API (no removed/renamed members or changed signatures/defaults)
- [X] No console output added to library code
- [ ] No magic numbers (literals extracted to `ControlDefaults`/`LayoutDefaults`)
- [ ] UI mutations from background threads are marshalled via `EnqueueOnUIThread`/`InvokeAsync`
- [ ] New source files carry the file-header banner

## Screenshots

<!-- If applicable, add screenshots for UI changes -->
<img width="1115" height="628" alt="image" src="https://github.com/user-attachments/assets/9a10d216-78b2-4397-9340-a38e0c06b1fd" />

<img width="1115" height="628" alt="image" src="https://github.com/user-attachments/assets/0ec5b54c-7be3-49b4-b53f-ddc17cbc55c2" />
