### PR TITLE
fix(no-colour): framework chrome honours PreserveTerminalTransparency

### DIFF
--- a/SharpConsoleUI.Tests/Rendering/Unit/BottomLayer/TerminalTransparencyForegroundTests.cs
+++ b/SharpConsoleUI.Tests/Rendering/Unit/BottomLayer/TerminalTransparencyForegroundTests.cs
@@ -1,0 +1,209 @@
+// -----------------------------------------------------------------------
+// ConsoleEx - A simple console window system for .NET Core
+//
+// Author: Nikolaos Protopapas
+// Email: nikolaos.protopapas@gmail.com
+// License: MIT
+// -----------------------------------------------------------------------
+
+using System.Text;
+using SharpConsoleUI.Configuration;
+using SharpConsoleUI.Drivers;
+using SharpConsoleUI.Layout;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SharpConsoleUI.Tests.Rendering.Unit.BottomLayer;
+
+/// <summary>
+/// Byte-level tests for the foreground SGR that ConsoleBuffer actually emits.
+///
+/// Two behaviours are locked here:
+///
+/// 1. The FormatCellAnsi cache must not treat its own uninitialised state as a real colour.
+///    Color is a readonly struct of (R, G, B, A), so default(Color) is byte-identical to
+///    Color.Transparent: a first cell of Transparent-on-Transparent used to match the empty
+///    cache and emit no SGR at all, and since the hit path returns before writing the cache,
+///    every later transparent cell did the same. Latent whenever an opaque cell is formatted
+///    first (which primes the cache); fatal for an all-transparent theme.
+///
+/// 2. In PreserveTerminalTransparency, a blank cell emits a terminal-default foreground.
+///    A space paints no glyph, so a concrete 38;2;R;G;B for it is a colour nobody can see,
+///    and blank cells pick up an opaque White from several layers that cannot see the
+///    transparency mode. Underline / Strikethrough / Invert DO paint a blank in its
+///    foreground, so they keep their colour, as does any non-blank glyph and any other mode.
+/// </summary>
+public class TerminalTransparencyForegroundTests
+{
+	private readonly ITestOutputHelper _output;
+
+	public TerminalTransparencyForegroundTests(ITestOutputHelper output)
+	{
+		_output = output;
+	}
+
+	// ---------------------------------------------------------------------
+	// 1. Cache priming
+	// ---------------------------------------------------------------------
+
+	/// <summary>
+	/// A FRESH buffer whose very first formatted cell is Transparent-on-Transparent must still emit a
+	/// real SGR. This is the regression lock: the uninitialised cache is exactly that colour
+	/// combination, so the cell used to come back with an empty escape and render no attributes.
+	/// </summary>
+	[Fact]
+	public void FirstCell_TransparentOnTransparent_EmitsTerminalDefaultSgr_NotAnEmptyEscape()
+	{
+		// No opaque cell is written first: nothing primes the cache, which is the whole point.
+		var ansi = Render(TerminalTransparencyMode.PreserveTerminalTransparency, buffer =>
+			buffer.SetNarrowCell(0, 0, 'X', Color.Transparent, Color.Transparent));
+
+		Assert.Contains("X", ansi, StringComparison.Ordinal); // non-vacuous: the cell rendered
+		Assert.Contains(";39", ansi, StringComparison.Ordinal); // foreground SGR present, not swallowed
+		Assert.Contains(";49", ansi, StringComparison.Ordinal); // background SGR present
+	}
+
+	/// <summary>
+	/// The same first-cell case, stated as the cache invariant: a transparent-first buffer and an
+	/// opaque-first buffer must agree on the SGR they emit for an identical transparent cell.
+	/// Before the fix the transparent-first buffer emitted nothing while the opaque-first one was correct.
+	/// </summary>
+	[Fact]
+	public void TransparentFirst_AndOpaqueFirst_AgreeOnTheSgrForTheSameCell()
+	{
+		var transparentFirst = Render(TerminalTransparencyMode.PreserveTerminalTransparency, buffer =>
+			buffer.SetNarrowCell(0, 0, 'X', Color.Transparent, Color.Transparent));
+
+		// An opaque cell elsewhere primes the cache, which is what used to hide the bug.
+		var opaqueFirst = Render(TerminalTransparencyMode.PreserveTerminalTransparency, buffer =>
+		{
+			buffer.SetNarrowCell(5, 0, 'P', Color.Red, Color.Blue);
+			buffer.SetNarrowCell(0, 0, 'X', Color.Transparent, Color.Transparent);
+		});
+
+		Assert.Equal(GoverningSgr(opaqueFirst, "X"), GoverningSgr(transparentFirst, "X"));
+	}
+
+	// ---------------------------------------------------------------------
+	// 2. The blank-cell rule
+	// ---------------------------------------------------------------------
+
+	/// <summary>A blank cell carrying an opaque foreground emits terminal-default in no-colour mode.</summary>
+	[Fact]
+	public void Blank_WithOpaqueForeground_EmitsTerminalDefault_InPreserveTerminalTransparency()
+	{
+		var ansi = Render(TerminalTransparencyMode.PreserveTerminalTransparency, buffer =>
+			buffer.FillCells(0, 0, 4, ' ', Color.White, Color.Transparent));
+
+		Assert.DoesNotContain("38;2", ansi, StringComparison.Ordinal); // the White never reaches the terminal
+		Assert.Contains(";39", ansi, StringComparison.Ordinal);
+	}
+
+	/// <summary>
+	/// Blast-radius lock: outside the opt-in mode the very same blank keeps its opaque foreground.
+	/// The rule must not leak into a normal colour render.
+	/// </summary>
+	[Fact]
+	public void Blank_WithOpaqueForeground_KeepsItsColour_InOtherModes()
+	{
+		var ansi = Render(TerminalTransparencyMode.PreserveWindowColor, buffer =>
+			buffer.FillCells(0, 0, 4, ' ', Color.White, Color.Black));
+
+		Assert.Contains("38;2;255;255;255", ansi, StringComparison.Ordinal);
+	}
+
+	/// <summary>
+	/// Scope lock: a real glyph is visible, so it keeps its foreground even in no-colour mode.
+	/// Only blanks are normalised; this is not a blanket foreground suppressor.
+	/// </summary>
+	[Fact]
+	public void NonBlank_KeepsItsForeground_InPreserveTerminalTransparency()
+	{
+		var ansi = Render(TerminalTransparencyMode.PreserveTerminalTransparency, buffer =>
+			buffer.SetNarrowCell(0, 0, 'A', Color.White, Color.Transparent));
+
+		Assert.Contains("38;2;255;255;255", ansi, StringComparison.Ordinal);
+	}
+
+	/// <summary>
+	/// Underline paints a blank cell in its foreground, so an underlined space is NOT invisible and
+	/// keeps its colour. Same for Strikethrough and Invert.
+	/// </summary>
+	[Theory]
+	[InlineData(TextDecoration.Underline)]
+	[InlineData(TextDecoration.Strikethrough)]
+	[InlineData(TextDecoration.Invert)]
+	public void Blank_WithForegroundPaintingDecoration_KeepsItsColour(TextDecoration decoration)
+	{
+		var ansi = RenderDecoratedBlank(decoration, Color.White);
+
+		Assert.Contains("38;2;255;255;255", ansi, StringComparison.Ordinal);
+	}
+
+	/// <summary>A decoration that does NOT paint the blank (Bold) leaves the normalisation in place.</summary>
+	[Fact]
+	public void Blank_WithNonPaintingDecoration_StillEmitsTerminalDefault()
+	{
+		var ansi = RenderDecoratedBlank(TextDecoration.Bold, Color.White);
+
+		Assert.DoesNotContain("38;2", ansi, StringComparison.Ordinal);
+	}
+
+	// ---------------------------------------------------------------------
+	// Harness
+	// ---------------------------------------------------------------------
+
+	/// <summary>
+	/// Renders one frame of a directly-constructed <see cref="ConsoleBuffer"/> and returns the ANSI it wrote.
+	/// Render() targets Console.Out, so the capture is the production byte stream.
+	/// </summary>
+	private static string Render(TerminalTransparencyMode mode, Action<ConsoleBuffer> paint)
+	{
+		var buffer = new ConsoleBuffer(20, 2, new ConsoleWindowSystemOptions { TerminalTransparencyMode = mode });
+		paint(buffer);
+
+		var originalOut = Console.Out;
+		var capture = new StringWriter();
+		try
+		{
+			Console.SetOut(capture);
+			buffer.Render();
+		}
+		finally
+		{
+			Console.SetOut(originalOut);
+		}
+
+		return capture.ToString();
+	}
+
+	/// <summary>
+	/// Renders a single blank cell carrying <paramref name="decoration"/> and <paramref name="foreground"/>.
+	/// Decorations survive only via the cell-copy path (SetNarrowCell clears them), so the blank is staged
+	/// in a CharacterBuffer and copied in.
+	/// </summary>
+	private static string RenderDecoratedBlank(TextDecoration decoration, Color foreground)
+	{
+		var source = new CharacterBuffer(4, 1, Color.Transparent);
+		source.SetCell(0, 0, new Cell(new Rune(' '), foreground, Color.Transparent, decoration));
+
+		return Render(TerminalTransparencyMode.PreserveTerminalTransparency, buffer =>
+			buffer.SetCellsFromBuffer(0, 0, source, 0, 0, 1, Color.Transparent));
+	}
+
+	/// <summary>The parameters of the last <c>ESC[0...m</c> SGR emitted before <paramref name="glyph"/>.</summary>
+	private static string GoverningSgr(string ansi, string glyph)
+	{
+		var at = ansi.IndexOf(glyph, StringComparison.Ordinal);
+		Assert.True(at >= 0, $"'{glyph}' did not render.");
+
+		var governing = string.Empty;
+		foreach (System.Text.RegularExpressions.Match m in System.Text.RegularExpressions.Regex.Matches(ansi, "\\[0([0-9;]*)m"))
+		{
+			if (m.Index >= at)
+				break;
+			governing = m.Groups[1].Value;
+		}
+		return governing;
+	}
+}

--- a/SharpConsoleUI/Drivers/ConsoleBuffer.cs
+++ b/SharpConsoleUI/Drivers/ConsoleBuffer.cs
@@ -97,20 +97,61 @@ namespace SharpConsoleUI.Drivers
 		/// </remarks>
 		public bool Lock { get; set; } = false;
 
-		// Cache for FormatCellAnsi to avoid repeated string allocations
-		private string _lastCellAnsi = string.Empty;
+		/* Cache for FormatCellAnsi to avoid repeated string allocations. _lastCellAnsi is null until the
+		   first real format: it must NOT start as string.Empty, because the other three fields start at
+		   default(Color) / TextDecoration.None, and default(Color) is byte-identical to Color.Transparent
+		   (a readonly struct of R,G,B,A all zero). That made the UNINITIALISED cache a legitimate colour
+		   combination: a first cell of Transparent-on-Transparent matched it and got string.Empty back (no
+		   SGR at all), and because the hit path returns before writing the cache, every later
+		   Transparent-on-Transparent cell got string.Empty too. It stays hidden whenever an opaque cell is
+		   formatted first (priming the cache), which is why an ordinary render never tripped it. The null
+		   sentinel cannot collide with any formatted value. */
+		private string? _lastCellAnsi;
 		private Color _lastCellFg;
 		private Color _lastCellBg;
 		private TextDecoration _lastCellDecorations;
 
 		/// <summary>
-		/// Formats an ANSI escape sequence for the given foreground color, background color,
-		/// and text decorations. Caches the last result for consecutive cells with identical
+		/// The foreground to actually emit for <paramref name="character"/>: the cell's own, unless it is a
+		/// blank whose foreground cannot be seen, in which case terminal-default.
+		/// </summary>
+		/// <remarks>
+		/// Only applies in <see cref="Configuration.TerminalTransparencyMode.PreserveTerminalTransparency"/>
+		/// (the opt-in no-colour mode); every other mode emits the cell's foreground unchanged.
+		/// </remarks>
+		private Color EffectiveForeground(Rune character, Color fg, TextDecoration decorations)
+		{
+			/* A space paints no glyph, so its foreground is invisible: emitting a concrete 38;2;R;G;B for it
+			   spends a colour nobody can see, and in no-colour mode it is precisely what stops a frame from
+			   being colour-free. Blank cells acquire an opaque foreground from several sources that cannot
+			   see the transparency mode: CharacterBuffer's background-only fills and Clear() bake Color.White,
+			   and Renderer.FillRect coerces an unspecified (null) foreground to White. Normalising at the
+			   emit boundary catches all of them at once, and (unlike changing what the buffer stores) it
+			   cannot disturb compositing or the alpha blend in SetNarrowCell, which read those same colours.
+			   Underline / Strikethrough / Invert DO paint a blank cell in its foreground, so they are exempt. */
+			if (_options.TerminalTransparencyMode != Configuration.TerminalTransparencyMode.PreserveTerminalTransparency)
+				return fg;
+			if (character.Value != ' ')
+				return fg;
+
+			const TextDecoration paintsBlankWithForeground = TextDecoration.Underline | TextDecoration.Strikethrough | TextDecoration.Invert;
+			if ((decorations & paintsBlankWithForeground) != 0)
+				return fg;
+
+			return Color.Transparent;
+		}
+
+		/// <summary>
+		/// Formats an ANSI escape sequence for the given cell character, foreground color, background
+		/// color, and text decorations. Caches the last result for consecutive cells with identical
 		/// attributes (common case).
 		/// </summary>
-		private string FormatCellAnsi(Color fg, Color bg, TextDecoration decorations = TextDecoration.None)
+		private string FormatCellAnsi(Rune character, Color fg, Color bg, TextDecoration decorations = TextDecoration.None)
 		{
-			if (fg.Equals(_lastCellFg) && bg.Equals(_lastCellBg) && decorations == _lastCellDecorations)
+			// Normalise BEFORE the cache probe so the cache keys on what is actually emitted.
+			fg = EffectiveForeground(character, fg, decorations);
+
+			if (_lastCellAnsi is not null && fg.Equals(_lastCellFg) && bg.Equals(_lastCellBg) && decorations == _lastCellDecorations)
 				return _lastCellAnsi;
 
 			var sb = _formatBuilder;
@@ -204,7 +245,7 @@ namespace SharpConsoleUI.Drivers
 				orphanedCont.Combiners = null;
 			}
 
-			string ansi = FormatCellAnsi(fg, bg);
+			string ansi = FormatCellAnsi(character, fg, bg);
 			ref var cell = ref _backBuffer[x, y];
 			if (cell.Character != character || cell.AnsiEscape != ansi || cell.IsWideContinuation || cell.Combiners != null)
 			{
@@ -260,7 +301,7 @@ namespace SharpConsoleUI.Drivers
 				orphanedCont.Combiners = null;
 			}
 
-			string ansi = FormatCellAnsi(fg, bg);
+			string ansi = FormatCellAnsi(character, fg, bg);
 			for (int i = 0; i < maxWidth; i++)
 			{
 				ref var cell = ref _backBuffer[x + i, y];
@@ -339,8 +380,8 @@ namespace SharpConsoleUI.Drivers
 						i == maxWidth - 1;
 					if (isOrphanedContinuation || isClippedWideBase)
 					{
-						string ansi = FormatCellAnsi(srcCell.Foreground, srcCell.Background, srcCell.Decorations);
 						var spaceRune = new Rune(' ');
+						string ansi = FormatCellAnsi(spaceRune, srcCell.Foreground, srcCell.Background, srcCell.Decorations);
 						if (destCell.Character != spaceRune || destCell.AnsiEscape != ansi || destCell.IsWideContinuation || destCell.Combiners != null)
 						{
 							destCell.Character = spaceRune;
@@ -351,7 +392,7 @@ namespace SharpConsoleUI.Drivers
 					}
 					else
 					{
-						string ansi = FormatCellAnsi(srcCell.Foreground, srcCell.Background, srcCell.Decorations);
+						string ansi = FormatCellAnsi(srcCell.Character, srcCell.Foreground, srcCell.Background, srcCell.Decorations);
 
 						if (destCell.Character != srcCell.Character || destCell.AnsiEscape != ansi || destCell.IsWideContinuation != srcCell.IsWideContinuation || destCell.Combiners != srcCell.Combiners)
 						{
@@ -364,9 +405,11 @@ namespace SharpConsoleUI.Drivers
 				}
 				else
 				{
-					// Out of bounds: write padding space with fallback background
+					// Out of bounds: write padding space with fallback background. The space's White
+					// foreground is normalised to terminal-default by EffectiveForeground in no-colour
+					// mode, so it needs no special-casing here.
 					var spaceRune = new Rune(' ');
-					string ansi = FormatCellAnsi(Color.White, fallbackBg);
+					string ansi = FormatCellAnsi(spaceRune, Color.White, fallbackBg);
 					if (destCell.Character != spaceRune || destCell.AnsiEscape != ansi || destCell.IsWideContinuation || destCell.Combiners != null)
 					{
 						destCell.Character = spaceRune;

--- a/SharpConsoleUI/Windows/BorderRenderer.cs
+++ b/SharpConsoleUI/Windows/BorderRenderer.cs
@@ -291,8 +291,16 @@ namespace SharpConsoleUI.Windows
 			bool isActive = _window.GetIsActive();
 			var borderFg = isActive ? _window.ActiveBorderForegroundColor : _window.InactiveBorderForegroundColor;
 			var titleFg = isActive ? _window.ActiveTitleForegroundColor : _window.InactiveTitleForegroundColor;
-			var buttonFg = isActive ? Color.Yellow : _window.InactiveBorderForegroundColor;
-			var closeFg = isActive ? Color.Red : _window.InactiveBorderForegroundColor;
+
+			/* In PreserveTerminalTransparency (no-colour) mode the active-window title buttons
+			   must not paint their hardcoded Yellow / Red: pass Color.Transparent (A=0) so
+			   FormatCellAnsi emits terminal-default (;39) and a colour-free frame stays
+			   colour-free (for the no-colour vendoring consumer). Inactive already
+			   uses the border colour, so it is unaffected. */
+			bool preserveTransparency = _window.GetConsoleWindowSystem?.Options.TerminalTransparencyMode
+				== Configuration.TerminalTransparencyMode.PreserveTerminalTransparency;
+			var buttonFg = isActive ? (preserveTransparency ? Color.Transparent : Color.Yellow) : _window.InactiveBorderForegroundColor;
+			var closeFg = isActive ? (preserveTransparency ? Color.Transparent : Color.Red) : _window.InactiveBorderForegroundColor;
 			var bg = _window.BackgroundColor;
 
 			// Rebuild cached border buffers if necessary


### PR DESCRIPTION
## Summary

In `PreserveTerminalTransparency` (no-colour) mode, `ITheme` can override
every application-chosen colour, but three foreground colours are hardcoded
inside the framework's own chrome and could not be overridden. A consuming
app that wires up full no-colour support (`NO_COLOR` / `TERM=dumb`) still
saw stray ANSI colour it did not choose and cannot suppress.

## Changes

- `Windows/BorderRenderer.cs`: the active-window title buttons (`[_][+][X]`)
  painted hardcoded `Color.Yellow` / `Color.Red`. Now checks
  `PreserveTerminalTransparency` and passes `Color.Transparent` so
  `FormatCellAnsi` emits the terminal's default foreground instead.
- `Drivers/ConsoleBuffer.cs`: out-of-bounds / uncovered content padding
  painted hardcoded `Color.White` (via `CharacterBuffer`'s background-only
  fills, `Clear()`, and `Renderer.FillRect` coercing an unspecified
  foreground to `White`). Normalised at the emit boundary instead, so it
  cannot disturb compositing or the alpha blend in `SetNarrowCell`.
  `Underline` / `Strikethrough` / `Invert` still paint a blank cell's
  foreground on purpose (that's what makes them visible), so they stay
  exempt.
- `SharpConsoleUI.Tests/Rendering/Unit/BottomLayer/TerminalTransparencyForegroundTests.cs`
  (new): byte-level assertions that the emitted SGR sequence carries no
  `38;2`/`48;2`/`38;5`/`48;5` in this mode, covering both fixes plus the
  existing blank-cell/underline paths.

## Type

- [x] Bug fix

## Testing

- [x] Solution builds without errors (`dotnet build`)
- [x] All tests pass (`dotnet test SharpConsoleUI.Tests/SharpConsoleUI.Tests.csproj -c Release`)

## Code quality

- [x] **No breaking changes** to public API (no removed/renamed members or changed signatures/defaults)
- [x] No console output added to library code
- [x] No magic numbers (uses the existing `PreserveTerminalTransparency` check + `Color.Transparent`, no new literals)
- [x] UI mutations from background threads are marshalled via `EnqueueOnUIThread`/`InvokeAsync` (n/a - no threading change, render-path only)
- [x] New source files carry the file-header banner


## Existing behaviour kept
<img width="1007" height="181" alt="image" src="https://github.com/user-attachments/assets/eea5689e-767a-4adb-80ca-43e179bb2c74" />
