### PR TITLE
Bump AngleSharp to 1.7.1 and AngleSharp.Css to 1.0.1

### DIFF
--- a/SharpConsoleUI.Tests/SharpConsoleUI.Tests.csproj
+++ b/SharpConsoleUI.Tests/SharpConsoleUI.Tests.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="1.4.0" />
-    <PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.213" />
+    <PackageReference Include="AngleSharp" Version="1.7.1" />
+    <PackageReference Include="AngleSharp.Css" Version="1.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/SharpConsoleUI/SharpConsoleUI.csproj
+++ b/SharpConsoleUI/SharpConsoleUI.csproj
@@ -56,8 +56,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AngleSharp" Version="1.4.0" />
-		<PackageReference Include="AngleSharp.Css" Version="1.0.0-beta.213" />
+		<PackageReference Include="AngleSharp" Version="1.7.1" />
+		<PackageReference Include="AngleSharp.Css" Version="1.0.1" />
 		<PackageReference Include="Markdig" Version="0.41.3" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="all" />
 		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />


### PR DESCRIPTION
AngleSharp before 1.5.0 has an mXSS issue (GHSA-pgww-w46g-26qg): MathML
annotation-xml elements get treated as HTML integration points, and
HtmlMarkupFormatter doesn't escape `<` and `>` in attribute values, so a crafted
payload can survive a parse/serialise round trip. NuGet flags it as NU1902 on
every restore.

AngleSharp.Css 1.0.1 requires AngleSharp `[1.5.0, 2.0.0)`, so 1.7.1 satisfies it.
It's also the first stable AngleSharp.Css, so this drops the beta pin too.

Before opening this I checked that the AOT smoke test still publishes clean with
IL2072 treated as an error and that the native binary runs, and that the test
suite is unchanged (the same 6 pre-existing threading failures before and after).

One note for reviewers: the scoped AngleSharp.Css trim-warning collapse in
`AotSmoke.csproj` is still needed. Disabling it brings back the same four IL2072
on the `CssCalc*` types, so this bump neither fixes nor worsens that.
