### PR TITLE
Keep the active tab visible when the header row overflows

### DIFF
--- a/SharpConsoleUI.Tests/Controls/TabControlOverflowTests.cs
+++ b/SharpConsoleUI.Tests/Controls/TabControlOverflowTests.cs
@@ -1,0 +1,201 @@
+// -----------------------------------------------------------------------
+// ConsoleEx - A simple console window system for .NET Core
+//
+// Author: Nikolaos Protopapas
+// Email: nikolaos.protopapas@gmail.com
+// License: MIT
+// -----------------------------------------------------------------------
+
+using System.Drawing;
+using SharpConsoleUI.Controls;
+using SharpConsoleUI.Drivers;
+using SharpConsoleUI.Events;
+using SharpConsoleUI.Tests.Infrastructure;
+using Xunit;
+using TabControl = SharpConsoleUI.Controls.TabControl;
+
+namespace SharpConsoleUI.Tests.Controls;
+
+/// <summary>
+/// A header row with more tabs than it has cells. The row draws the run that fits and scrolls it so the
+/// active tab is always in view; before it did neither, drawing from index 0 and clipping, so the tabs
+/// past the edge were gone and the active tab with them whenever it sat late enough in the order.
+/// </summary>
+public class TabControlOverflowTests
+{
+	private const int WindowWidth = 40;
+
+	private static string StripAnsiCodes(IEnumerable<string> lines) =>
+		string.Join("\n", lines.Select(line =>
+			System.Text.RegularExpressions.Regex.Replace(line, @"\x1b\[[0-9;]*m", "")));
+
+	private static MarkupControl Label(string text) => new(new List<string> { text });
+
+	/// <summary>Eight tabs of eleven cells each in a forty-cell window: three of them fit.</summary>
+	private static (Window Window, TabControl Tabs) Crowded(int active)
+	{
+		var system = TestWindowSystemBuilder.CreateTestSystem();
+		var window = new Window(system) { Width = WindowWidth, Height = 12 };
+		var tabs = new TabControl { Height = 8 };
+		for (int i = 0; i < 8; i++)
+			tabs.AddTab($"Channel {i}", Label($"Content {i}"));
+		tabs.ActiveTabIndex = active;
+		window.AddControl(tabs);
+		return (window, tabs);
+	}
+
+	/// <summary>
+	/// The headline: the tab the control says is active is one the reader can actually see. It used to be
+	/// drawn only if it happened to fall inside the first few tabs' worth of cells.
+	/// </summary>
+	[Theory]
+	[InlineData(0)]
+	[InlineData(3)]
+	[InlineData(7)]
+	public void ActiveTabIsAlwaysDrawn(int active)
+	{
+		var (window, _) = Crowded(active);
+
+		var plain = StripAnsiCodes(window.RenderAndGetVisibleContent());
+
+		Assert.Contains($"Channel {active}", plain);
+	}
+
+	/// <summary>
+	/// And the row says there is more to see. Without a marker a truncated strip is indistinguishable
+	/// from a complete one — which was the whole of "how do I know there are other tabs?".
+	/// </summary>
+	[Fact]
+	public void TabsBeyondEitherEdgeAreMarked()
+	{
+		var (window, _) = Crowded(active: 4);
+
+		var header = StripAnsiCodes(window.RenderAndGetVisibleContent()).Split('\n')[0];
+
+		Assert.Contains('‹', header);
+		Assert.Contains('›', header);
+	}
+
+	/// <summary>The first tab being active is not a scrolled state, so no left marker is drawn.</summary>
+	[Fact]
+	public void AStripAtItsStartIsMarkedOnlyOnTheRight()
+	{
+		var (window, _) = Crowded(active: 0);
+
+		var header = StripAnsiCodes(window.RenderAndGetVisibleContent()).Split('\n')[0];
+
+		Assert.DoesNotContain('‹', header);
+		Assert.Contains('›', header);
+	}
+
+	/// <summary>…and the last tab being active leaves nothing past the right edge to mark.</summary>
+	[Fact]
+	public void AStripAtItsEndIsMarkedOnlyOnTheLeft()
+	{
+		var (window, _) = Crowded(active: 7);
+
+		var header = StripAnsiCodes(window.RenderAndGetVisibleContent()).Split('\n')[0];
+
+		Assert.Contains('‹', header);
+		Assert.DoesNotContain('›', header);
+	}
+
+	/// <summary>A row with space for all its tabs is drawn exactly as it always was.</summary>
+	[Fact]
+	public void ARowWithRoomIsUnchanged()
+	{
+		var system = TestWindowSystemBuilder.CreateTestSystem();
+		var window = new Window(system) { Width = 80, Height = 12 };
+		var tabs = new TabControl { Height = 8 };
+		tabs.AddTab("One", Label("1"));
+		tabs.AddTab("Two", Label("2"));
+		window.AddControl(tabs);
+
+		var header = StripAnsiCodes(window.RenderAndGetVisibleContent()).Split('\n')[0];
+
+		Assert.Contains("One", header);
+		Assert.Contains("Two", header);
+		Assert.DoesNotContain('‹', header);
+		Assert.DoesNotContain('›', header);
+	}
+
+	/// <summary>
+	/// Clicking picks the tab that is under the pointer, not the one that would be there if the row had
+	/// never scrolled. The hit test reads the same layout the paint does; two copies of the arithmetic is
+	/// exactly how a scrolled strip ends up selecting a tab the user cannot see.
+	/// </summary>
+	[Fact]
+	public void ClickingAScrolledStripPicksTheTabUnderThePointer()
+	{
+		var (window, tabs) = Crowded(active: 7);
+		window.RenderAndGetVisibleContent();
+
+		// One cell past the ‹ marker is the first drawn tab's leading pad; two past it is its title.
+		var strip = tabs.LayoutStrip(tabs.TabPages, tabs.ActiveTabIndex, tabs.ActualWidth - tabs.Margin.Left - tabs.Margin.Right);
+		int firstDrawn = strip.First;
+		int x = strip.Offsets[0] + 1;
+
+		var args = new MouseEventArgs(
+			new List<MouseFlags> { MouseFlags.Button1Clicked },
+			new Point(x, 0),
+			new Point(x, 0),
+			new Point(x, 0));
+		tabs.ProcessMouseEvent(args);
+
+		Assert.True(firstDrawn > 0, "the strip should be scrolled for this to mean anything");
+		Assert.Equal(firstDrawn, tabs.ActiveTabIndex);
+	}
+
+	/// <summary>
+	/// Turning the markers off gives their cells back to the tabs; the row still scrolls, because an
+	/// active tab nobody can see is a defect rather than a preference.
+	/// </summary>
+	[Fact]
+	public void IndicatorsCanBeTurnedOffAndTheRowStillScrolls()
+	{
+		var (window, tabs) = Crowded(active: 7);
+		tabs.ShowTabScrollIndicators = false;
+
+		var header = StripAnsiCodes(window.RenderAndGetVisibleContent()).Split('\n')[0];
+
+		Assert.DoesNotContain('‹', header);
+		Assert.DoesNotContain('›', header);
+		Assert.Contains("Channel 7", header);
+	}
+
+	/// <summary>
+	/// A control that has never been painted has no arranged width, and that means "not known" rather
+	/// than "no room" — it reports every tab as drawn, which is what callers saw before any of this.
+	/// </summary>
+	[Fact]
+	public void AnUnpaintedControlReportsEveryTab()
+	{
+		var tabs = new TabControl();
+		for (int i = 0; i < 5; i++)
+			tabs.AddTab($"Channel {i}", Label($"{i}"));
+
+		var strip = tabs.LayoutStrip(tabs.TabPages, 0, 0);
+
+		Assert.Equal(0, strip.First);
+		Assert.Equal(5, strip.Count);
+		Assert.False(strip.MoreLeft);
+		Assert.False(strip.MoreRight);
+	}
+
+	/// <summary>
+	/// A row too narrow for even one tab still draws that one, clipped, rather than drawing nothing: the
+	/// alternative is a header row that is blank at exactly the width where it is needed most.
+	/// </summary>
+	[Fact]
+	public void ARowNarrowerThanASingleTabStillDrawsIt()
+	{
+		var tabs = new TabControl();
+		tabs.AddTab("A very long tab title indeed", Label("1"));
+		tabs.AddTab("Another", Label("2"));
+
+		var strip = tabs.LayoutStrip(tabs.TabPages, 1, 6);
+
+		Assert.Equal(1, strip.Count);
+		Assert.Equal(1, strip.First);
+	}
+}

--- a/SharpConsoleUI/Configuration/ControlDefaults.cs
+++ b/SharpConsoleUI/Configuration/ControlDefaults.cs
@@ -1139,5 +1139,20 @@ namespace SharpConsoleUI.Configuration
 		public const string LogViewerExportDefaultFileName = "export.log";
 
 		#endregion
+
+		#region Tab Control
+
+		/// <summary>Glyph marking that a TabControl header row has tabs before the first one drawn
+		/// (single left-pointing angle quotation mark, U+2039). Reliably 1-cell wide.</summary>
+		public const char TabScrollLeftGlyph = '‹';
+
+		/// <summary>Glyph marking that a TabControl header row has tabs after the last one drawn
+		/// (single right-pointing angle quotation mark, U+203A). Reliably 1-cell wide.</summary>
+		public const char TabScrollRightGlyph = '›';
+
+		/// <summary>Cells one scroll indicator occupies on the tab header row while it is shown.</summary>
+		public const int TabScrollIndicatorWidth = 1;
+
+		#endregion
 	}
 }

--- a/SharpConsoleUI/Controls/TabControl/TabControl.Input.cs
+++ b/SharpConsoleUI/Controls/TabControl/TabControl.Input.cs
@@ -57,18 +57,27 @@ namespace SharpConsoleUI.Controls
 			return GetTabIndexAtX(clickX, snapshot);
 		}
 
-		private int GetTabIndexAtX(int clickX, List<TabPage> tabs)
+		private int GetTabIndexAtX(int clickX, List<TabPage> tabs) =>
+			GetTabIndexAtX(clickX, HeaderStrip(tabs));
+
+		private int GetTabIndexAtX(int clickX, TabStripLayout strip)
 		{
-			int currentX = Margin.Left;
-			for (int i = 0; i < tabs.Count; i++)
+			for (int drawn = 0; drawn < strip.Count; drawn++)
 			{
-				int innerWidth = MarkupParser.StripLength(tabs[i].Title) + 2 + (tabs[i].IsClosable ? 1 : 0);
-				if (clickX >= currentX && clickX < currentX + innerWidth)
-					return i;
-				currentX += innerWidth + 1; // + separator
+				int start = Margin.Left + strip.Offsets[drawn];
+				if (clickX >= start && clickX < start + strip.Widths[drawn])
+					return strip.First + drawn;
 			}
 			return -1;
 		}
+
+		/// <summary>
+		/// The header row as it was last painted. It has to come from the same <see cref="LayoutStrip"/>
+		/// the paint uses, or a scrolled strip is hit-tested against tab positions nobody can see — the
+		/// click would land on whichever tab happens to sit at that X when counting from index 0.
+		/// </summary>
+		private TabStripLayout HeaderStrip(IReadOnlyList<TabPage> tabs) =>
+			LayoutStrip(tabs, ActiveTabIndex, ActualWidth - Margin.Left - Margin.Right);
 
 		/// <inheritdoc/>
 		public bool ProcessMouseEvent(MouseEventArgs args)
@@ -96,14 +105,13 @@ namespace SharpConsoleUI.Controls
 			{
 				// Calculate which tab was clicked (account for left margin)
 				int clickX = args.Position.X;
-				int tabIndex = GetTabIndexAtX(clickX, snapshot);
+				var strip = HeaderStrip(snapshot);
+				int tabIndex = GetTabIndexAtX(clickX, strip);
 
 				if (tabIndex >= 0 && args.HasFlag(MouseFlags.Button1Clicked))
 				{
-					// Check if click landed on the close button
-					int currentX = Margin.Left;
-					for (int j = 0; j < tabIndex; j++)
-						currentX += MarkupParser.StripLength(snapshot[j].Title) + 2 + (snapshot[j].IsClosable ? 1 : 0) + 1;
+					// Check if click landed on the close button, at the far end of that tab's own cells
+					int currentX = Margin.Left + strip.Offsets[tabIndex - strip.First];
 
 					if (snapshot[tabIndex].IsClosable && clickX == currentX + MarkupParser.StripLength(snapshot[tabIndex].Title) + 2)
 					{

--- a/SharpConsoleUI/Controls/TabControl/TabControl.Rendering.cs
+++ b/SharpConsoleUI/Controls/TabControl/TabControl.Rendering.cs
@@ -7,6 +7,7 @@
 // -----------------------------------------------------------------------
 
 using System.Linq;
+using SharpConsoleUI.Configuration;
 using SharpConsoleUI.Extensions;
 using SharpConsoleUI.Helpers;
 using SharpConsoleUI.Layout;
@@ -77,8 +78,22 @@ namespace SharpConsoleUI.Controls
 			int activeTabStartX = -1;
 			int activeTabEndX = -1;
 
-			for (int i = 0; i < snapshot.Count; i++)
+			// Which tabs fit, positioned so the active one is among them. Without this the row drew from
+			// index 0 and clipped, so a strip narrower than its tabs simply stopped — with the active tab
+			// itself off the end whenever it sat late enough in the order.
+			var strip = LayoutStrip(snapshot, activeIdx, headerRight - headerLeft);
+
+			// MoreLeft/MoreRight are facts about the strip; the property decides whether to say them out
+			// loud. With it off no cell was reserved for them either, so nothing here has room to draw.
+			if (strip.MoreLeft && _showTabScrollIndicators)
 			{
+				buffer.SetNarrowCell(x, headerY, ControlDefaults.TabScrollLeftGlyph, Color.Grey, bgColor);
+				x++;
+			}
+
+			for (int drawn = 0; drawn < strip.Count; drawn++)
+			{
+				int i = strip.First + drawn;
 				bool isActive = i == activeIdx;
 				var title = $" {snapshot[i].Title} ";
 
@@ -113,8 +128,8 @@ namespace SharpConsoleUI.Controls
 				if (isActive)
 					activeTabEndX = x;
 
-				// Draw separator
-				if (x < headerRight && i < snapshot.Count - 1)
+				// Draw separator — between the tabs actually drawn, not between every tab there is.
+				if (x < headerRight && drawn < strip.Count - 1)
 				{
 					buffer.SetNarrowCell(x, headerY, '│', Color.Grey, bgColor);
 					x++;
@@ -127,10 +142,20 @@ namespace SharpConsoleUI.Controls
 			int hintStartX = headerRight - navHintDisplayWidth;
 			int tabsEndX = x; // capture before fill loops modify x
 
+			// Drawn after the tabs and before the fill, so the cell it needs is one the fill will not
+			// take back. It sits at the row's own right edge rather than after the last tab: it marks
+			// where the row ends, and a strip a cell short of full would otherwise strand it mid-row.
+			int fillRight = headerRight;
+			if (strip.MoreRight && _showTabScrollIndicators && headerRight - 1 >= headerLeft)
+			{
+				buffer.SetNarrowCell(headerRight - 1, headerY, ControlDefaults.TabScrollRightGlyph, Color.Grey, bgColor);
+				fillRight--;
+			}
+
 			if (_headerStyle == TabHeaderStyle.Classic)
 			{
 				// Fill remaining header space with ─
-				while (x < headerRight)
+				while (x < fillRight)
 				{
 					buffer.SetNarrowCell(x, headerY, '─', Color.Grey, bgColor);
 					x++;
@@ -139,7 +164,7 @@ namespace SharpConsoleUI.Controls
 			else
 			{
 				// Fill remaining row 1 space with spaces
-				while (x < headerRight)
+				while (x < fillRight)
 				{
 					buffer.SetNarrowCell(x, headerY, ' ', Color.Grey, bgColor);
 					x++;

--- a/SharpConsoleUI/Controls/TabControl/TabControl.Strip.cs
+++ b/SharpConsoleUI/Controls/TabControl/TabControl.Strip.cs
@@ -1,0 +1,136 @@
+// -----------------------------------------------------------------------
+// ConsoleEx - A simple console window system for .NET Core
+//
+// Author: Nikolaos Protopapas
+// Email: nikolaos.protopapas@gmail.com
+// License: MIT
+// -----------------------------------------------------------------------
+
+using SharpConsoleUI.Configuration;
+using SharpConsoleUI.Parsing;
+
+namespace SharpConsoleUI.Controls
+{
+	/// <summary>
+	/// Which tabs the header row can show, and where each of them sits on it.
+	/// </summary>
+	/// <param name="First">Index of the first tab drawn.</param>
+	/// <param name="Count">How many tabs are drawn, starting at <paramref name="First"/>.</param>
+	/// <param name="MoreLeft">Whether tabs exist before <paramref name="First"/>.</param>
+	/// <param name="MoreRight">Whether tabs exist after the last drawn one.</param>
+	/// <param name="Offsets">
+	/// Each drawn tab's X, relative to the left edge of the header area (that is, past
+	/// <see cref="BaseControl.Margin"/>'s left). A separator, where there is one, sits immediately after
+	/// the tab at <c>Offsets[i] + Widths[i]</c>.
+	/// </param>
+	/// <param name="Widths">Each drawn tab's width: its title, the space either side, and its close button.</param>
+	internal readonly record struct TabStripLayout(
+		int First,
+		int Count,
+		bool MoreLeft,
+		bool MoreRight,
+		IReadOnlyList<int> Offsets,
+		IReadOnlyList<int> Widths);
+
+	public partial class TabControl
+	{
+		/// <summary>
+		/// Lays the header row out: the run of tabs that fits, positioned so the active one is always
+		/// among them, and whether there are tabs past either end.
+		/// <para>
+		/// The scroll position is <b>derived, never stored</b>: it is the smallest starting index that
+		/// still leaves room for the active tab. That makes the strip a pure function of its tabs, its
+		/// active index and its width, so painting and hit-testing cannot disagree about it, and moving
+		/// back towards the first tab always returns the strip to its unscrolled state.
+		/// </para>
+		/// <para>
+		/// A width of zero or less means the control has not been painted yet and its arranged width is
+		/// not known. Everything is reported as drawn in that case, which is what callers assumed before
+		/// there was any scrolling at all.
+		/// </para>
+		/// </summary>
+		/// <param name="tabs">The tab pages, in strip order.</param>
+		/// <param name="activeIndex">The active tab, which the returned run always contains.</param>
+		/// <param name="available">Cells the header row has for tabs and indicators.</param>
+		internal TabStripLayout LayoutStrip(IReadOnlyList<TabPage> tabs, int activeIndex, int available)
+		{
+			if (tabs.Count == 0)
+				return new TabStripLayout(0, 0, false, false, Array.Empty<int>(), Array.Empty<int>());
+
+			var widths = new int[tabs.Count];
+			for (int i = 0; i < tabs.Count; i++)
+				widths[i] = TabWidth(tabs[i]);
+
+			if (available <= 0)
+				return Unscrolled(tabs.Count, widths);
+
+			int active = Math.Clamp(activeIndex, 0, tabs.Count - 1);
+			int indicator = _showTabScrollIndicators ? ControlDefaults.TabScrollIndicatorWidth : 0;
+
+			// The smallest first index that still reaches the end of the active tab. Monotone in `first`,
+			// so the first one that fits is the least one — and when even the active tab alone is wider
+			// than the row, the loop lands on it and it is drawn clipped, as it would have been anyway.
+			int first = 0;
+			while (first < active && !Reaches(first, active, widths, tabs.Count, indicator, available))
+				first++;
+
+			var offsets = new List<int>(tabs.Count - first);
+			var drawn = new List<int>(tabs.Count - first);
+			int x = first > 0 ? indicator : 0;
+			int last = first;
+
+			for (int i = first; i < tabs.Count; i++)
+			{
+				int separator = i > first ? 1 : 0;
+
+				// Room for the indicator has to be kept back while any tab still follows this one, or the
+				// strip fills to its last cell and has nowhere to say that it was truncated.
+				int reserve = i < tabs.Count - 1 ? indicator : 0;
+				if (i > first && x + separator + widths[i] + reserve > available)
+					break;
+
+				x += separator;
+				offsets.Add(x);
+				drawn.Add(widths[i]);
+				x += widths[i];
+				last = i;
+			}
+
+			return new TabStripLayout(first, drawn.Count, first > 0, last < tabs.Count - 1, offsets, drawn);
+		}
+
+		/// <summary>One tab's width: its title, the space either side of it, and its close button.</summary>
+		private static int TabWidth(TabPage tab) =>
+			MarkupParser.StripLength(tab.Title) + 2 + (tab.IsClosable ? 1 : 0);
+
+		/// <summary>
+		/// Whether a strip starting at <paramref name="first"/> reaches the end of the tab at
+		/// <paramref name="active"/> — counting the separators between them and whichever scroll
+		/// indicators that run would need.
+		/// </summary>
+		private static bool Reaches(
+			int first, int active, IReadOnlyList<int> widths, int count, int indicator, int available)
+		{
+			int needed = first > 0 ? indicator : 0;
+			for (int i = first; i <= active; i++)
+				needed += widths[i] + (i < active ? 1 : 0);
+			if (active < count - 1)
+				needed += indicator;
+
+			return needed <= available;
+		}
+
+		private static TabStripLayout Unscrolled(int count, IReadOnlyList<int> widths)
+		{
+			var offsets = new int[count];
+			int x = 0;
+			for (int i = 0; i < count; i++)
+			{
+				offsets[i] = x;
+				x += widths[i] + 1; // + separator
+			}
+
+			return new TabStripLayout(0, count, false, false, offsets, widths);
+		}
+	}
+}

--- a/SharpConsoleUI/Controls/TabControl/TabControl.cs
+++ b/SharpConsoleUI/Controls/TabControl/TabControl.cs
@@ -179,6 +179,23 @@ namespace SharpConsoleUI.Controls
 			set => SetProperty(ref _showTabHeader, value);
 		}
 
+		private bool _showTabScrollIndicators = true;
+
+		/// <summary>
+		/// Gets or sets whether a ‹ or › is drawn at an edge the header row has more tabs beyond.
+		/// Each costs one cell of the row while it is shown, and only while it is shown.
+		/// Default: true.
+		/// </summary>
+		/// <remarks>
+		/// The header row scrolls to keep the active tab visible whatever this is set to; turning the
+		/// indicators off only stops the row saying that it has done so.
+		/// </remarks>
+		public bool ShowTabScrollIndicators
+		{
+			get => _showTabScrollIndicators;
+			set => SetProperty(ref _showTabScrollIndicators, value);
+		}
+
 		/// <summary>
 		/// Returns the number of rows consumed by the tab header (1 for Classic, 2 for Separator/AccentedSeparator).
 		/// </summary>

--- a/docs/controls/TabControl.md
+++ b/docs/controls/TabControl.md
@@ -8,6 +8,18 @@ TabControl is a container control that displays multiple pages of content (tabs)
 
 **Important**: TabControl does not automatically provide scrolling. Wrap tab content in `ScrollablePanelBuilder` to enable scrolling for content that exceeds the visible area.
 
+### More tabs than the header row can hold
+
+When the tabs are wider than the control, the header row shows the run that fits and positions it so
+the **active tab is always visible**. A `‹` or `›` marks an edge that has more tabs beyond it, so a
+truncated row is distinguishable from a complete one; set `ShowTabScrollIndicators` to `false` to give
+those cells back to the tabs. The row still follows the active tab either way — changing
+`ActiveTabIndex`, clicking a header, or pressing Left/Right while the header has focus scrolls it as
+needed.
+
+The scroll position is derived from the active tab rather than stored, so the row returns to its
+unscrolled state as soon as an early tab is selected again.
+
 ## Properties
 
 | Property | Type | Default | Description |
@@ -23,6 +35,7 @@ TabControl is a container control that displays multiple pages of content (tabs)
 | `BackgroundColor` | `Color` | `Color.Black` | Background color for control |
 | `ForegroundColor` | `Color` | `Color.White` | Foreground color for control |
 | `IsEnabled` | `bool` | `true` | Enable/disable tab control |
+| `ShowTabScrollIndicators` | `bool` | `true` | Draw `‹` / `›` at an edge the header row has more tabs beyond |
 
 ## Events
 


### PR DESCRIPTION
## The bug

`PaintTabHeaders` draws its tabs left to right from `x = headerLeft` and writes each one with `WriteCellsClipped` against the header rectangle. There is no first-visible-tab offset anywhere in `TabControl`, so a header row narrower than its tabs simply stops drawing partway along — **including when the tab it stops before is the active one**. The `×` and the `│` go with it (each gated on `x < headerRight`), and the built-in `" ← → "` hint cannot cover for it: that is drawn only when the strip has keyboard focus *and* there is slack left after the tabs, which is exactly the case where there is none.

Eight tabs in a 40-cell window, rendered through `RenderAndGetVisibleContent`, before this change:

```
active=0: | Channel 0 │ Channel 1 │ Channel 2 │ C|
active=4: | Channel 0 │ Channel 1 │ Channel 2 │ C|
active=7: | Channel 0 │ Channel 1 │ Channel 2 │ C|
```

The row is identical whichever tab is active — the user has selected `Channel 7` and the header says `Channel 0`.

After:

```
active=0: | Channel 0 │ Channel 1 │ Channel 2 ──›|
active=4: |‹ Channel 2 │ Channel 3 │ Channel 4 ─›|
active=7: |‹ Channel 5 │ Channel 6 │ Channel 7 ──|
```

## What changed

- **The row shows the run of tabs that fits, positioned so the active tab is among them.** The scroll position is *derived, not stored*: it is the smallest starting index that still leaves room for the active tab. That makes the strip a pure function of `(tabs, activeIndex, width)`, so the paint and the hit test cannot disagree about it, and selecting an early tab returns the row to its unscrolled state. There is no scroll gesture on the header row for stored state to serve; if one is ever added, that is the point at which state would earn its place.
- **`‹` / `›` mark an edge with more tabs beyond it**, so a truncated row is distinguishable from a complete one. New public property `ShowTabScrollIndicators` (default `true`) turns them off and gives their cells back to the tabs; the row still follows the active tab either way, since an active tab nobody can see is a defect rather than a preference.
- **One layout, two callers.** `ProcessMouseEvent` had its own copy of the tab arithmetic in two places (the tab hit test and the close-button check). Both now read the same `LayoutStrip` the paint does — otherwise a scrolled row selects whichever tab happens to sit at that X counting from index 0, which is a tab the user cannot see.

## Compatibility

- **A row with space for all its tabs is drawn exactly as before** — `ARowWithRoomIsUnchanged` pins that, and it is the case nearly every strip is in.
- The only behaviour that changes is for rows that were *already* dropping tabs on the floor. I have treated that as a bug fix rather than gating it behind an opt-in, since the old paint could not say which tab was active; happy to put it behind a property instead if you would rather the default paint never move.
- No public member removed, renamed or re-signatured. One property added, documented in `docs/controls/TabControl.md`.
- Glyphs and the indicator width are named constants in `Configuration/ControlDefaults.cs`, per `CONTRIBUTING.md`.

## Tests

`SharpConsoleUI.Tests/Controls/TabControlOverflowTests.cs` — 10 cases: the active tab is drawn for a first, middle and last selection; both markers appear only at an edge that has tabs beyond it; a click on a scrolled row picks the tab under the pointer; the indicators can be turned off with the row still scrolling; an unpainted control (no arranged width) reports every tab, which is what callers saw before; and a row too narrow for even one tab still draws that one, clipped, rather than drawing nothing.

Full suite: **5695 passed, 0 failed** on `net10.0`.

## Not in this PR

Wheel-scrolling the header row, and eliding over-long titles to fit more tabs. Both are worth having; neither is needed to stop the row hiding the tab it says is active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)