### PR TITLE
feat(TableControl): keyboard Shift+range and right-click multi-select

### DIFF
--- a/SharpConsoleUI.Tests/Controls/DragAutoScrollTargetTests.cs
+++ b/SharpConsoleUI.Tests/Controls/DragAutoScrollTargetTests.cs
@@ -124,7 +124,7 @@ public class DragAutoScrollTargetTests
 	[Fact]
 	public void Registry_Step_DrivesTarget_WhenOutOfBounds()
 	{
-		var system = new ConsoleWindowSystem(new NetConsoleDriver(RenderMode.Buffer));
+		var system = new ConsoleWindowSystem(new HeadlessConsoleDriver());
 		var fake = new FakeTarget { LastDragRelativeY = 15, ViewportHeightRows = 10 }; // 6 below bottom
 		system.RegisterDragAutoScroll(fake);
 
@@ -137,7 +137,7 @@ public class DragAutoScrollTargetTests
 	[Fact]
 	public void Registry_Step_NoOp_WhenInBounds()
 	{
-		var system = new ConsoleWindowSystem(new NetConsoleDriver(RenderMode.Buffer));
+		var system = new ConsoleWindowSystem(new HeadlessConsoleDriver());
 		var fake = new FakeTarget { LastDragRelativeY = 3, ViewportHeightRows = 10 };
 		system.RegisterDragAutoScroll(fake);
 		system.StepDragAutoScrollForTest(1000);

--- a/SharpConsoleUI.Tests/Controls/MultilineEditBuilderTests.cs
+++ b/SharpConsoleUI.Tests/Controls/MultilineEditBuilderTests.cs
@@ -6,6 +6,7 @@
 // License: MIT
 // -----------------------------------------------------------------------
 
+using System;
 using SharpConsoleUI.Controls;
 using Xunit;
 using Ctl = SharpConsoleUI.Builders.Controls;
@@ -23,7 +24,7 @@ public class MultilineEditBuilderTests
 			.WithHeight(4)
 			.Build();
 
-		Assert.Equal("line 1\nline 2", editor.Content);
+		Assert.Equal("line 1" + Environment.NewLine + "line 2", editor.Content); // Content getter joins lines with Environment.NewLine
 		Assert.True(editor.ReadOnly);
 		Assert.Equal(4, editor.Height);            // WithHeight sets the layout height
 	}

--- a/SharpConsoleUI.Tests/Core/ConsoleWindowSystemWatchdogTests.cs
+++ b/SharpConsoleUI.Tests/Core/ConsoleWindowSystemWatchdogTests.cs
@@ -79,14 +79,14 @@ public class ConsoleWindowSystemWatchdogTests
 	[Fact]
 	public void FormatCurrentCallback_ReturnsNull_WhenNoFrameSet()
 	{
-		var sys = new ConsoleWindowSystem(RenderMode.Buffer);
+		var sys = new ConsoleWindowSystem(new HeadlessConsoleDriver());
 		Assert.Null(sys.FormatCurrentCallback());
 	}
 
 	[Fact]
 	public void FormatCurrentCallback_FreeFormLabel_FormatsAsOpColonLabel()
 	{
-		var sys = new ConsoleWindowSystem(RenderMode.Buffer);
+		var sys = new ConsoleWindowSystem(new HeadlessConsoleDriver());
 		sys.SetFrameLabel("SaveTimer");
 		Assert.Equal("UIAction: SaveTimer", sys.FormatCurrentCallback());
 	}
@@ -94,7 +94,7 @@ public class ConsoleWindowSystemWatchdogTests
 	[Fact]
 	public void FormatCurrentCallback_StructuredWindowAndControl_NamesBoth()
 	{
-		var sys = new ConsoleWindowSystem(RenderMode.Buffer);
+		var sys = new ConsoleWindowSystem(new HeadlessConsoleDriver());
 		var window = new Window(sys) { Title = "Editor" };
 		var control = new SharpConsoleUI.Controls.MarkupControl(new System.Collections.Generic.List<string> { "x" });
 		sys.SetFrame(window, control, UiOp.Click);
@@ -104,7 +104,7 @@ public class ConsoleWindowSystemWatchdogTests
 	[Fact]
 	public void FormatCurrentCallback_WindowOnly_OmitsControlClause()
 	{
-		var sys = new ConsoleWindowSystem(RenderMode.Buffer);
+		var sys = new ConsoleWindowSystem(new HeadlessConsoleDriver());
 		var window = new Window(sys) { Title = "Dashboard" };
 		sys.SetFrame(window, null, UiOp.Render);
 		Assert.Equal("Render on 'Dashboard'", sys.FormatCurrentCallback());
@@ -115,7 +115,7 @@ public class ConsoleWindowSystemWatchdogTests
 	[Fact]
 	public void UiCallbackScope_RestoresPreviousFrame_OnDispose()
 	{
-		var sys = new ConsoleWindowSystem(RenderMode.Buffer);
+		var sys = new ConsoleWindowSystem(new HeadlessConsoleDriver());
 		var window = new Window(sys) { Title = "Outer" };
 		sys.SetFrame(window, null, UiOp.Key);
 
@@ -131,7 +131,7 @@ public class ConsoleWindowSystemWatchdogTests
 	[Fact]
 	public void UiCallbackScope_Nested_InnermostWins_OuterRestored()
 	{
-		var sys = new ConsoleWindowSystem(RenderMode.Buffer);
+		var sys = new ConsoleWindowSystem(new HeadlessConsoleDriver());
 
 		using (new UiCallbackScope(sys, "A"))
 		{

--- a/SharpConsoleUI.Tests/Core/InvokeAsyncTests.cs
+++ b/SharpConsoleUI.Tests/Core/InvokeAsyncTests.cs
@@ -11,7 +11,7 @@ public class InvokeAsyncTests
 	[Fact]
 	public async Task InvokeAsync_MarshalsWork_AndReturnsResult()
 	{
-		var sys = new ConsoleWindowSystem(RenderMode.Buffer, options: new ConsoleWindowSystemOptions());
+		var sys = new ConsoleWindowSystem(new HeadlessConsoleDriver(), options: new ConsoleWindowSystemOptions());
 		Assert.False(sys.IsOnUIThread);                  // not running → uiThreadId is -1
 
 		var task = sys.InvokeAsync(() => 21 * 2);

--- a/SharpConsoleUI.Tests/Core/SynchronizationContextInstalledTests.cs
+++ b/SharpConsoleUI.Tests/Core/SynchronizationContextInstalledTests.cs
@@ -28,7 +28,7 @@ public class SynchronizationContextInstalledTests
 	[Fact]
 	public void False_BeforeRun()
 	{
-		var sys = new ConsoleWindowSystem(RenderMode.Buffer);
+		var sys = new ConsoleWindowSystem(new HeadlessConsoleDriver());
 		Assert.False(sys.SynchronizationContextInstalled);
 	}
 
@@ -36,7 +36,7 @@ public class SynchronizationContextInstalledTests
 	public void True_DuringRun_WhenOptedIn_AndFalse_AfterShutdown()
 	{
 		var opts = new ConsoleWindowSystemOptions() with { InstallSynchronizationContext = true };
-		var sys = new ConsoleWindowSystem(RenderMode.Buffer, options: opts);
+		var sys = new ConsoleWindowSystem(new HeadlessConsoleDriver(), options: opts);
 
 		var t = new Thread(() => { try { sys.Run(); } catch { } }) { IsBackground = true };
 		t.Start();
@@ -53,7 +53,7 @@ public class SynchronizationContextInstalledTests
 	public void False_DuringRun_WhenNotOptedIn()
 	{
 		var opts = new ConsoleWindowSystemOptions() with { InstallSynchronizationContext = false };
-		var sys = new ConsoleWindowSystem(RenderMode.Buffer, options: opts);
+		var sys = new ConsoleWindowSystem(new HeadlessConsoleDriver(), options: opts);
 
 		bool? observedDuringRun = null;
 		var t = new Thread(() => { try { sys.Run(); } catch { } }) { IsBackground = true };

--- a/SharpConsoleUI.Tests/Helpers/LinkHitTesterTests.cs
+++ b/SharpConsoleUI.Tests/Helpers/LinkHitTesterTests.cs
@@ -27,6 +27,7 @@ namespace SharpConsoleUI.Tests.Helpers
 		{
 			// col = relativeX - originX = 15 - 5 = 10 ∈ [10,14)
 			var hit = LinkHitTester.FindAt(Row, originX: 5, relativeX: 15);
+			Assert.True(hit.HasValue);
 			Assert.Equal("urlB", hit.Value.Url);
 		}
 

--- a/SharpConsoleUI.Tests/Helpers/SequenceHelperMouseTests.cs
+++ b/SharpConsoleUI.Tests/Helpers/SequenceHelperMouseTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using SharpConsoleUI.Drivers;
 using SharpConsoleUI.Helpers;
 using Xunit;
@@ -9,6 +10,25 @@ namespace SharpConsoleUI.Tests.Helpers;
 
 public class SequenceHelperMouseTests
 {
+	// SequenceHelper.GetMouse tracks click/press/drag state in private static fields shared across
+	// every call in the process. xUnit runs test classes without an explicit [Collection] in parallel
+	// with each other by default, and even sequentially within this class the click tests' async
+	// DefaultDebounceMs (300ms) reset could still be pending when the next test starts under CI load,
+	// so a fresh test would inherit e.g. a lingering _isButtonClicked and be misread as a double-click.
+	// Resetting these fields directly via reflection before every test is deterministic and avoids
+	// relying on wall-clock sleeps racing the debounce timer.
+	public SequenceHelperMouseTests()
+	{
+		Type type = typeof(SequenceHelper);
+		type.GetField("_isButtonClicked", BindingFlags.NonPublic | BindingFlags.Static)!.SetValue(null, false);
+		type.GetField("_isButtonDoubleClicked", BindingFlags.NonPublic | BindingFlags.Static)!.SetValue(null, false);
+		type.GetField("_isButtonPressed", BindingFlags.NonPublic | BindingFlags.Static)!.SetValue(null, false);
+		type.GetField("_isButtonTripleClicked", BindingFlags.NonPublic | BindingFlags.Static)!.SetValue(null, false);
+		type.GetField("_lastMouseButtonPressed", BindingFlags.NonPublic | BindingFlags.Static)!.SetValue(null, null);
+		type.GetField("_point", BindingFlags.NonPublic | BindingFlags.Static)!.SetValue(null, null);
+		type.GetField("_lastClickTime", BindingFlags.NonPublic | BindingFlags.Static)!.SetValue(null, DateTime.MinValue);
+	}
+
 	// Builds the ConsoleKeyInfo[] GetMouse expects from the raw SGR body (e.g. "<32;3;5M").
 	private static ConsoleKeyInfo[] Cki(string seq) =>
 		seq.Select(ch => new ConsoleKeyInfo(ch, default, false, false, false)).ToArray();
@@ -40,5 +60,34 @@ public class SequenceHelperMouseTests
 		// A fresh button press (code 0, no motion bit) must not be reported as a drag.
 		SequenceHelper.GetMouse(Cki("<0;3;1M"), out List<MouseFlags> flags, out _, NoOp);
 		Assert.False(flags[0].HasFlag(MouseFlags.Button1Dragged), $"flags were {flags[0]}");
+	}
+
+	[Fact]
+	public void GetMouse_CtrlClick_SurfacesButton1ClickedWithCtrl()
+	{
+		// SGR code 16 = button 0 (Button1) + Ctrl bit (0x10). buttonState used to be compared with
+		// `== MouseFlags.Button1Pressed/Released` while still carrying the OR'd-in ButtonCtrl bit, so
+		// the comparison never matched and Button1Clicked was never synthesized (mirrors the
+		// UnixStdinReader ExtractButtonState bug fixed in fc0948ec, but in this separate Windows path).
+		SequenceHelper.GetMouse(Cki("<16;3;1M"), out _, out _, NoOp);
+		SequenceHelper.GetMouse(Cki("<16;3;1m"), out List<MouseFlags> flags, out _, NoOp);
+
+		Assert.Contains(MouseFlags.Button1Clicked, flags);
+		Assert.True(flags[0].HasFlag(MouseFlags.ButtonCtrl), $"flags were {string.Join(",", flags)}");
+	}
+
+	[Fact]
+	public void GetMouse_ShiftClick_SurfacesButton1ClickedWithShift()
+	{
+		// SGR code 4 = button 0 (Button1) + Shift bit (0x04) alone, with no Alt/Ctrl. The old
+		// hand-enumerated switch table never listed a bare-Shift code for Button1/Button2 at all
+		// (only Shift combined with Alt and/or Ctrl was covered for Button3), so buttonState stayed
+		// at its default 0 and the press/release/click were never recognized — the click was
+		// silently dropped instead of just missing its modifier.
+		SequenceHelper.GetMouse(Cki("<4;3;1M"), out _, out _, NoOp);
+		SequenceHelper.GetMouse(Cki("<4;3;1m"), out List<MouseFlags> flags, out _, NoOp);
+
+		Assert.Contains(MouseFlags.Button1Clicked, flags);
+		Assert.True(flags[0].HasFlag(MouseFlags.ButtonShift), $"flags were {string.Join(",", flags)}");
 	}
 }

--- a/SharpConsoleUI.Tests/Themes/ThemeDerivationTests.cs
+++ b/SharpConsoleUI.Tests/Themes/ThemeDerivationTests.cs
@@ -146,7 +146,7 @@ public class ThemeDerivationTests
 	[Fact]
 	public void RegisterAndSwitch_EndToEnd_MakesDerivedThemeLive()
 	{
-		var system = new ConsoleWindowSystem(new NetConsoleDriver(RenderMode.Buffer));
+		var system = new ConsoleWindowSystem(new HeadlessConsoleDriver());
 
 		var derived = Theme.From(new ModernGrayTheme())
 			.WithName("MyDark")

--- a/SharpConsoleUI.Tests/WindowScrollByTests.cs
+++ b/SharpConsoleUI.Tests/WindowScrollByTests.cs
@@ -9,7 +9,7 @@ public class WindowScrollByTests
 	[Fact]
 	public void ScrollBy_BeforeRender_DoesNotThrow_AndIsNoOp()
 	{
-		var system = new ConsoleWindowSystem(new NetConsoleDriver(RenderMode.Buffer));
+		var system = new ConsoleWindowSystem(new HeadlessConsoleDriver());
 		var window = new Window(system) { IsScrollable = true };
 		var ex = Record.Exception(() => window.ScrollBy(5));
 		Assert.Null(ex);
@@ -19,7 +19,7 @@ public class WindowScrollByTests
 	[Fact]
 	public void ScrollBy_WhenNotScrollable_DoesNothing()
 	{
-		var system = new ConsoleWindowSystem(new NetConsoleDriver(RenderMode.Buffer));
+		var system = new ConsoleWindowSystem(new HeadlessConsoleDriver());
 		var window = new Window(system) { IsScrollable = false };
 		window.ScrollBy(5);
 		Assert.Equal(0, window.ScrollOffset);

--- a/SharpConsoleUI.Tests/WindowThreadOnUITests.cs
+++ b/SharpConsoleUI.Tests/WindowThreadOnUITests.cs
@@ -56,7 +56,7 @@ public class WindowThreadOnUITests
 	[Fact]
 	public void UIWindowThread_RunsOnUIThread_BeforeAndAfterAwait()
 	{
-		var sys = new ConsoleWindowSystem(RenderMode.Buffer); // headless buffer render
+		var sys = new ConsoleWindowSystem(new HeadlessConsoleDriver());
 
 		bool? beforeAwaitOnUi = null;
 		bool? afterAwaitOnUi = null;
@@ -90,7 +90,7 @@ public class WindowThreadOnUITests
 	[Fact]
 	public void DefaultWindowThread_RunsOffUIThread_UnderRunLoop()
 	{
-		var sys = new ConsoleWindowSystem(RenderMode.Buffer); // headless buffer render
+		var sys = new ConsoleWindowSystem(new HeadlessConsoleDriver());
 
 		bool? observedOnUi = null;
 		var window = new Window(sys, async (win, ct) =>
@@ -133,7 +133,7 @@ public class WindowThreadOnUITests
 	[Fact]
 	public void Builder_WithWindowThreadOnUI_RunsOnUIThread()
 	{
-		var sys = new ConsoleWindowSystem(RenderMode.Buffer); // headless buffer render
+		var sys = new ConsoleWindowSystem(new HeadlessConsoleDriver());
 
 		bool? observedOnUi = null;
 		var window = new SharpConsoleUI.Builders.WindowBuilder(sys)
@@ -171,7 +171,7 @@ public class WindowThreadOnUITests
 	[Fact]
 	public void UIWindowThread_DirectMutation_RendersAndSurvives()
 	{
-		var sys = new ConsoleWindowSystem(RenderMode.Buffer); // headless buffer render
+		var sys = new ConsoleWindowSystem(new HeadlessConsoleDriver());
 
 		var markup = new MarkupControl(new List<string> { "initial" });
 		Exception? delegateError = null;
@@ -238,7 +238,7 @@ public class WindowThreadOnUITests
 	[Fact]
 	public void UIWindowThread_ClosedDuringStartGap_DoesNotRunDelegate()
 	{
-		var sys = new ConsoleWindowSystem(RenderMode.Buffer); // headless buffer render
+		var sys = new ConsoleWindowSystem(new HeadlessConsoleDriver());
 
 		bool delegateRan = false;
 		var window = new SharpConsoleUI.Builders.WindowBuilder(sys)
@@ -273,7 +273,7 @@ public class WindowThreadOnUITests
 	public void UIWindowThread_UIAffinity_IndependentOfGlobalSyncContext()
 	{
 		var options = new ConsoleWindowSystemOptions() with { InstallSynchronizationContext = false };
-		var sys = new ConsoleWindowSystem(RenderMode.Buffer, options); // headless buffer render
+		var sys = new ConsoleWindowSystem(new HeadlessConsoleDriver(), options);
 
 		bool? observedOnUi = null;
 		var window = new SharpConsoleUI.Builders.WindowBuilder(sys)

--- a/SharpConsoleUI/Controls/TableControl/TableControl.Keyboard.cs
+++ b/SharpConsoleUI/Controls/TableControl/TableControl.Keyboard.cs
@@ -34,7 +34,7 @@ public partial class TableControl
 				if (_hoveredRowIndex != -1) _hoveredRowIndex = -1;
 				if (_selectedRowIndex < rowCount - 1)
 				{
-					SetSelectedRow(_selectedRowIndex + 1);
+					ExtendOrMoveSelection(_selectedRowIndex + 1, key.Modifiers);
 					return true;
 				}
 				return false;
@@ -43,7 +43,7 @@ public partial class TableControl
 				if (_hoveredRowIndex != -1) _hoveredRowIndex = -1;
 				if (_selectedRowIndex > 0)
 				{
-					SetSelectedRow(_selectedRowIndex - 1);
+					ExtendOrMoveSelection(_selectedRowIndex - 1, key.Modifiers);
 					return true;
 				}
 				return false;
@@ -188,10 +188,13 @@ public partial class TableControl
 				}
 				return false;
 
-			case ConsoleKey.Spacebar when _checkboxMode && _multiSelectEnabled:
+			// Not gated on _checkboxMode - the only way to toggle a row into a growing multi-selection from
+			// the keyboard when Shift+Up/Down hasn't already covered it (e.g. picking non-contiguous rows).
+			case ConsoleKey.Spacebar when _multiSelectEnabled:
 				if (_selectedRowIndex >= 0)
 				{
 					ToggleRowSelection(_selectedRowIndex);
+					_selectionAnchorRowIndex = _selectedRowIndex;
 					return true;
 				}
 				return false;
@@ -210,4 +213,30 @@ public partial class TableControl
 				return false;
 		}
 	}
+
+	/// <summary>
+	/// Moves the cursor to <paramref name="newIndex"/>. Plain Up/Down resets the range anchor to the new
+	/// cursor position (so a later Shift+Up/Down always starts fresh from wherever the cursor now is).
+	/// Shift+Up/Down instead keeps the existing anchor fixed and re-selects the whole anchor..newIndex
+	/// range every time, so growing/shrinking the range by holding Shift and repeating the arrow key
+	/// works like Explorer/Excel. This is keyboard-only multi-select: this terminal does not deliver
+	/// Shift/Ctrl mouse-click modifiers to the app at all (confirmed via raw MouseFlags logging), so
+	/// Shift/Ctrl+Click can't be relied on here.
+	/// </summary>
+	private void ExtendOrMoveSelection(int newIndex, ConsoleModifiers modifiers)
+	{
+		if (_multiSelectEnabled && modifiers.HasFlag(ConsoleModifiers.Shift))
+		{
+			int anchor = _selectionAnchorRowIndex >= 0 ? _selectionAnchorRowIndex : _selectedRowIndex;
+			_selectionAnchorRowIndex = anchor;
+			_selectedRowIndices.Clear();
+			SelectRange(anchor, newIndex);
+		}
+		else
+		{
+			_selectionAnchorRowIndex = newIndex;
+		}
+		SetSelectedRow(newIndex);
+	}
 }
+

--- a/SharpConsoleUI/Controls/TableControl/TableControl.Mouse.cs
+++ b/SharpConsoleUI/Controls/TableControl/TableControl.Mouse.cs
@@ -75,7 +75,9 @@ public partial class TableControl
 			return true;
 		}
 
-		// Right-click: select row/cell first, then fire event
+		// Right-click: select row/cell first, then fire event. When multi-select is enabled, this also
+		// extends the range from the anchor to the clicked row (a Shift+click stand-in, since this
+		// terminal does not deliver Shift/Ctrl mouse-click modifiers - see ExtendOrMoveSelection).
 		if (args.HasFlag(MouseFlags.Button3Clicked))
 		{
 			if (_isEditing)
@@ -85,6 +87,13 @@ public partial class TableControl
 			int rowIdx = GetRowIndexAtY(args.Position.Y);
 			if (rowIdx >= 0)
 			{
+				if (_multiSelectEnabled)
+				{
+					int anchor = _selectionAnchorRowIndex >= 0 ? _selectionAnchorRowIndex : _selectedRowIndex;
+					_selectionAnchorRowIndex = anchor;
+					_selectedRowIndices.Clear();
+					SelectRange(anchor, rowIdx);
+				}
 				SetSelectedRow(rowIdx);
 				if (_cellNavigationEnabled)
 				{
@@ -335,8 +344,11 @@ public partial class TableControl
 
 			// Fresh press over a data row: just move the cursor, don't touch multi-select state
 			// (multi-select toggling happens on the Button1Clicked / Up phase to avoid double-toggle).
+			// EXCEPTION: a Shift-click's range (Up phase below) is anchored on whatever _selectedRowIndex
+			// was BEFORE this click - moving it here first would make every range collapse to just the
+			// pressed row (anchor == target).
 			int pressRow = GetRowIndexAtY(args.Position.Y);
-			if (pressRow >= 0)
+			if (pressRow >= 0 && !(_multiSelectEnabled && args.HasFlag(MouseFlags.ButtonShift)))
 				SetSelectedRow(pressRow);
 			return true;
 		}
@@ -411,7 +423,14 @@ public partial class TableControl
 								row.IsChecked = false;
 						}
 					}
+					// Seed the set with this row so a plain click establishes a real one-row selection a
+					// following Ctrl/Shift-click can build on - otherwise Ctrl-clicking a second row only
+					// ever produces a 1-row set (looks like the selection moved rather than grew).
 					_selectedRowIndices.Clear();
+					_selectedRowIndices.Add(rowIdx);
+					// Re-anchor keyboard Shift+Up/Down range-select (see TableControl.Keyboard.cs) here too,
+					// so it starts fresh from wherever was just plain-clicked.
+					_selectionAnchorRowIndex = rowIdx;
 				}
 				SetSelectedRow(rowIdx);
 			}

--- a/SharpConsoleUI/Controls/TableControl/TableControl.Mouse.cs
+++ b/SharpConsoleUI/Controls/TableControl/TableControl.Mouse.cs
@@ -348,6 +348,23 @@ public partial class TableControl
 			// was BEFORE this click - moving it here first would make every range collapse to just the
 			// pressed row (anchor == target).
 			int pressRow = GetRowIndexAtY(args.Position.Y);
+
+			// A plain (no Ctrl/Shift) press on a data row seeds a click-and-drag range select - the mouse-only
+			// stand-in for Shift+Click, since terminals routinely swallow Shift+Click for native text selection.
+			_isRowDragSelecting = _multiSelectEnabled && pressRow >= 0 && !IsClickOnHeader(args)
+				&& !args.HasFlag(MouseFlags.ButtonShift) && !args.HasFlag(MouseFlags.ButtonCtrl)
+				&& !(_checkboxMode && IsClickOnCheckbox(args.Position.X));
+
+			// A Ctrl-held press on a data row seeds a Ctrl+drag: additional ranges added on top of whatever
+			// was already selected, instead of the plain drag's "replace the whole selection" behavior.
+			bool isCtrlDragSelecting = _multiSelectEnabled && pressRow >= 0 && !IsClickOnHeader(args)
+				&& args.HasFlag(MouseFlags.ButtonCtrl) && !args.HasFlag(MouseFlags.ButtonShift)
+				&& !(_checkboxMode && IsClickOnCheckbox(args.Position.X));
+			_ctrlDragBaseSelection = isCtrlDragSelecting ? new HashSet<int>(_selectedRowIndices) : null;
+
+			if (_isRowDragSelecting || isCtrlDragSelecting)
+				_selectionAnchorRowIndex = pressRow;
+
 			if (pressRow >= 0 && !(_multiSelectEnabled && args.HasFlag(MouseFlags.ButtonShift)))
 				SetSelectedRow(pressRow);
 			return true;
@@ -355,12 +372,42 @@ public partial class TableControl
 
 		if (phase == GesturePhase.Move)
 		{
-			// A cell drag stays owned by the cells area; nothing to extend here.
+			// A cell drag stays owned by the cells area. A plain-press drag seeded above extends the
+			// multi-select range live to the row under the pointer.
+			if (_isRowDragSelecting)
+			{
+				int dragRowIdx = GetRowIndexAtY(args.Position.Y);
+				if (dragRowIdx >= 0)
+				{
+					_selectedRowIndices.Clear();
+					SelectRange(_selectionAnchorRowIndex, dragRowIdx);
+					SetSelectedRow(dragRowIdx);
+				}
+			}
+			else if (_ctrlDragBaseSelection != null)
+			{
+				// Recompute from the pre-drag snapshot each time (rather than accumulating) so backtracking
+				// the pointer past the anchor correctly drops rows the live preview had added.
+				int dragRowIdx = GetRowIndexAtY(args.Position.Y);
+				if (dragRowIdx >= 0)
+				{
+					_selectedRowIndices.Clear();
+					_selectedRowIndices.UnionWith(_ctrlDragBaseSelection);
+					SelectRange(_selectionAnchorRowIndex, dragRowIdx);
+					SetSelectedRow(dragRowIdx);
+				}
+			}
 			return true;
 		}
 
 		// Up phase: the Button1Clicked discrete actions. If the release did not carry Button1Clicked
 		// (e.g. a bare Button1Released ending a press) there is nothing further to do.
+		// Captured once here (rather than read from the field below) so every exit path from this phase -
+		// header sort, empty-area click, or a normal row click - consistently ends the drag-select gesture.
+		bool wasDragSelecting = _isRowDragSelecting;
+		HashSet<int>? ctrlDragBase = _ctrlDragBaseSelection;
+		_isRowDragSelecting = false;
+		_ctrlDragBaseSelection = null;
 		if (!args.HasFlag(MouseFlags.Button1Clicked))
 			return true;
 
@@ -394,7 +441,19 @@ public partial class TableControl
 		{
 			if (_multiSelectEnabled && args.HasFlag(MouseFlags.ButtonCtrl))
 			{
-				ToggleRowSelection(rowIdx);
+				// A completed Ctrl+drag (anchor differs from the release row) adds the whole dragged range
+				// on top of whatever was selected before the drag; a plain Ctrl+click (no movement) keeps the
+				// original single-row toggle behavior.
+				if (ctrlDragBase != null && _selectionAnchorRowIndex != rowIdx)
+				{
+					_selectedRowIndices.Clear();
+					_selectedRowIndices.UnionWith(ctrlDragBase);
+					SelectRange(_selectionAnchorRowIndex, rowIdx);
+				}
+				else
+				{
+					ToggleRowSelection(rowIdx);
+				}
 				SetSelectedRow(rowIdx);
 			}
 			else if (_multiSelectEnabled && args.HasFlag(MouseFlags.ButtonShift))
@@ -423,13 +482,15 @@ public partial class TableControl
 								row.IsChecked = false;
 						}
 					}
-					// Seed the set with this row so a plain click establishes a real one-row selection a
-					// following Ctrl/Shift-click can build on - otherwise Ctrl-clicking a second row only
-					// ever produces a 1-row set (looks like the selection moved rather than grew).
+					// A click-and-drag range select (seeded on Down, extended on Move) finalizes here using its
+					// original press-row anchor, so a completed drag isn't collapsed back down to the single
+					// release row. A plain click (no drag) has anchor == rowIdx, so this degrades to the same
+					// single-row selection as before.
+					int anchor = wasDragSelecting && _selectionAnchorRowIndex >= 0 ? _selectionAnchorRowIndex : rowIdx;
 					_selectedRowIndices.Clear();
-					_selectedRowIndices.Add(rowIdx);
+					SelectRange(anchor, rowIdx);
 					// Re-anchor keyboard Shift+Up/Down range-select (see TableControl.Keyboard.cs) here too,
-					// so it starts fresh from wherever was just plain-clicked.
+					// so it starts fresh from wherever was just plain-clicked/dragged.
 					_selectionAnchorRowIndex = rowIdx;
 				}
 				SetSelectedRow(rowIdx);
@@ -553,6 +614,20 @@ public partial class TableControl
 		if (!string.IsNullOrEmpty(_title)) hy++;
 		if (_borderStyle != BorderStyle.None) hy++;
 		return hy;
+	}
+
+	/// <summary>Returns the Y coordinate of the given display row index, for unit-testing row hit detection.</summary>
+	internal int RowYForTest(int displayIndex)
+	{
+		int dataStartY = Margin.Top;
+		if (!string.IsNullOrEmpty(_title)) dataStartY++;
+		if (_borderStyle != BorderStyle.None) dataStartY++;
+		if (_showHeader) dataStartY++;
+		if (_showHeader && _borderStyle != BorderStyle.None) dataStartY++;
+
+		int effectiveRowIndex = displayIndex - _scrollOffset;
+		int rowOffset = (_showRowSeparators && _borderStyle != BorderStyle.None) ? effectiveRowIndex * 2 : effectiveRowIndex;
+		return dataStartY + rowOffset;
 	}
 
 	private bool IsClickOnVerticalScrollbar(MouseEventArgs args)

--- a/SharpConsoleUI/Controls/TableControl/TableControl.cs
+++ b/SharpConsoleUI/Controls/TableControl/TableControl.cs
@@ -116,6 +116,10 @@ public partial class TableControl : BaseControl, IInteractiveControl, IFocusable
 	private bool _checkboxMode = false;
 	private bool _clearSelectionOnEmptyClick = false;
 	private HashSet<int> _selectedRowIndices = new();
+	// Anchor for keyboard Shift+Up/Down range selection - the row a shift-extended range grows from/to.
+	// Reset to the cursor row on every non-shift cursor move so a fresh Shift+arrow always starts from
+	// wherever the cursor currently is (matches Explorer/Excel range-select semantics).
+	private int _selectionAnchorRowIndex = -1;
 
 	/// <summary>
 	/// When true, a left-click in the data area that does not hit any row

--- a/SharpConsoleUI/Controls/TableControl/TableControl.cs
+++ b/SharpConsoleUI/Controls/TableControl/TableControl.cs
@@ -120,6 +120,14 @@ public partial class TableControl : BaseControl, IInteractiveControl, IFocusable
 	// Reset to the cursor row on every non-shift cursor move so a fresh Shift+arrow always starts from
 	// wherever the cursor currently is (matches Explorer/Excel range-select semantics).
 	private int _selectionAnchorRowIndex = -1;
+	// True from a plain (no modifier) Button1 press on a data row through its release - lets a
+	// click-and-drag extend the multi-select range live, as a mouse-only stand-in for Shift+Click
+	// (terminals routinely swallow Shift+Click for their own text selection - see #Shift-click bug).
+	private bool _isRowDragSelecting = false;
+	// Non-null while a Ctrl+drag is in progress: the selection snapshot taken on press, so each Move
+	// can recompute the live preview as (snapshot ∪ anchor..pointer range) instead of accumulating rows
+	// the pointer has since backtracked past. Null when no Ctrl+drag is active.
+	private HashSet<int>? _ctrlDragBaseSelection = null;
 
 	/// <summary>
 	/// When true, a left-click in the data area that does not hit any row
@@ -1511,6 +1519,8 @@ public partial class TableControl : BaseControl, IInteractiveControl, IFocusable
 		_gesture.Reset();
 		_vThumbDragging = false;
 		_hThumbDragging = false;
+		_isRowDragSelecting = false;
+		_ctrlDragBaseSelection = null;
 
 		if (_dataSource != null)
 			_dataSource.CollectionChanged -= OnDataSourceCollectionChanged;

--- a/SharpConsoleUI/Helpers/SequenceHelper.cs
+++ b/SharpConsoleUI/Helpers/SequenceHelper.cs
@@ -243,201 +243,68 @@ namespace SharpConsoleUI.Helpers
 					//pos.Y = int.Parse (value) + Console.WindowTop - 1;
 					pos.Y = int.Parse(value) - 1;
 
-					switch (buttonCode)
+					if ((buttonCode & 0x40) != 0)
 					{
-						case 0:
-						case 8:
-						case 16:
-						case 24:
-						case 32:
-						case 36:
-						case 40:
-						case 48:
-						case 56:
-							buttonState = c == 'M'
-											  ? MouseFlags.Button1Pressed
-											  : MouseFlags.Button1Released;
+						// Wheel codes: xterm maps a modifier held during a vertical wheel tick to a
+						// synthetic horizontal tilt (WheeledLeft/Right) rather than a plain modifier bit,
+						// so this table is deliberately kept as its own hardcoded lookup.
+						switch (buttonCode)
+						{
+							case 64:
+								buttonState = MouseFlags.WheeledUp;
+								break;
 
-							break;
+							case 65:
+								buttonState = MouseFlags.WheeledDown;
+								break;
 
-						case 1:
-						case 9:
-						case 17:
-						case 25:
-						case 33:
-						case 37:
-						case 41:
-						case 45:
-						case 49:
-						case 53:
-						case 57:
-						case 61:
-							buttonState = c == 'M'
-											  ? MouseFlags.Button2Pressed
-											  : MouseFlags.Button2Released;
+							case 68:
+							case 72:
+							case 80:
+								buttonState = MouseFlags.WheeledLeft; // Shift/Alt/Ctrl+WheeledUp
 
-							break;
+								break;
 
-						case 2:
-						case 10:
-						case 14:
-						case 18:
-						case 22:
-						case 26:
-						case 30:
-						case 34:
-						case 42:
-						case 46:
-						case 50:
-						case 54:
-						case 58:
-						case 62:
-							buttonState = c == 'M'
-											  ? MouseFlags.Button3Pressed
-											  : MouseFlags.Button3Released;
+							case 69:
+							case 73:
+							case 81:
+								buttonState = MouseFlags.WheeledRight; // Shift/Alt/Ctrl+WheeledDown
 
-							break;
-
-						case 35:
-						case 39:
-						case 43:
-						case 47:
-						case 51:
-						case 55:
-						case 59:
-						case 63:
-							buttonState = MouseFlags.ReportMousePosition;
-
-							break;
-
-						case 64:
-							buttonState = MouseFlags.WheeledUp;
-
-							break;
-
-						case 65:
-							buttonState = MouseFlags.WheeledDown;
-
-							break;
-
-						case 68:
-						case 72:
-						case 80:
-							buttonState = MouseFlags.WheeledLeft; // Shift/Ctrl+WheeledUp
-
-							break;
-
-						case 69:
-						case 73:
-						case 81:
-							buttonState = MouseFlags.WheeledRight; // Shift/Ctrl+WheeledDown
-
-							break;
+								break;
+						}
 					}
-
-					// Modifiers.
-					switch (buttonCode)
+					else
 					{
-						case 8:
-						case 9:
-						case 10:
-						case 43:
-							buttonState |= MouseFlags.ButtonAlt;
+						// Base button + modifiers computed from the SGR bit layout (bits 0-1 = button,
+						// 0x04/0x08/0x10 = Shift/Alt/Ctrl, 0x20 = motion) instead of a hand-enumerated
+						// case table: the old table only listed specific button+modifier combinations
+						// and silently dropped any code it didn't recognize (e.g. a bare Shift+Click was
+						// code 4, present in neither switch), leaving buttonState at its default 0 and
+						// the click never recognized at all.
+						switch (buttonCode & 0x03)
+						{
+							case 0:
+								buttonState = c == 'M' ? MouseFlags.Button1Pressed : MouseFlags.Button1Released;
+								break;
 
-							break;
+							case 1:
+								buttonState = c == 'M' ? MouseFlags.Button2Pressed : MouseFlags.Button2Released;
+								break;
 
-						case 14:
-						case 47:
-							buttonState |= MouseFlags.ButtonAlt | MouseFlags.ButtonShift;
+							case 2:
+								buttonState = c == 'M' ? MouseFlags.Button3Pressed : MouseFlags.Button3Released;
+								break;
 
-							break;
+							case 3:
+								if ((buttonCode & 0x20) != 0)
+									buttonState = MouseFlags.ReportMousePosition;
+								break;
+						}
 
-						case 16:
-						case 17:
-						case 18:
-						case 51:
-							buttonState |= MouseFlags.ButtonCtrl;
-
-							break;
-
-						case 22:
-						case 55:
-							buttonState |= MouseFlags.ButtonCtrl | MouseFlags.ButtonShift;
-
-							break;
-
-						case 24:
-						case 25:
-						case 26:
-						case 59:
-							buttonState |= MouseFlags.ButtonCtrl | MouseFlags.ButtonAlt;
-
-							break;
-
-						case 30:
-						case 63:
-							buttonState |= MouseFlags.ButtonCtrl | MouseFlags.ButtonShift | MouseFlags.ButtonAlt;
-
-							break;
-
-						case 32:
-						case 33:
-						case 34:
-							buttonState |= MouseFlags.ReportMousePosition;
-
-							break;
-
-						case 36:
-						case 37:
-							buttonState |= MouseFlags.ReportMousePosition | MouseFlags.ButtonShift;
-
-							break;
-
-						case 39:
-						case 68:
-						case 69:
-							buttonState |= MouseFlags.ButtonShift;
-
-							break;
-
-						case 40:
-						case 41:
-						case 42:
-							buttonState |= MouseFlags.ReportMousePosition | MouseFlags.ButtonAlt;
-
-							break;
-
-						case 45:
-						case 46:
-							buttonState |= MouseFlags.ReportMousePosition | MouseFlags.ButtonAlt | MouseFlags.ButtonShift;
-
-							break;
-
-						case 48:
-						case 49:
-						case 50:
-							buttonState |= MouseFlags.ReportMousePosition | MouseFlags.ButtonCtrl;
-
-							break;
-
-						case 53:
-						case 54:
-							buttonState |= MouseFlags.ReportMousePosition | MouseFlags.ButtonCtrl | MouseFlags.ButtonShift;
-
-							break;
-
-						case 56:
-						case 57:
-						case 58:
-							buttonState |= MouseFlags.ReportMousePosition | MouseFlags.ButtonCtrl | MouseFlags.ButtonAlt;
-
-							break;
-
-						case 61:
-						case 62:
-							buttonState |= MouseFlags.ReportMousePosition | MouseFlags.ButtonCtrl | MouseFlags.ButtonShift | MouseFlags.ButtonAlt;
-
-							break;
+						if ((buttonCode & 0x20) != 0) buttonState |= MouseFlags.ReportMousePosition;
+						if ((buttonCode & 0x04) != 0) buttonState |= MouseFlags.ButtonShift;
+						if ((buttonCode & 0x08) != 0) buttonState |= MouseFlags.ButtonAlt;
+						if ((buttonCode & 0x10) != 0) buttonState |= MouseFlags.ButtonCtrl;
 					}
 				}
 			}
@@ -459,6 +326,14 @@ namespace SharpConsoleUI.Helpers
 
 			mouseFlags = [MouseFlags.AllEvents];
 
+			// buttonState mixes the button/wheel action with Shift/Alt/Ctrl (OR'd in by the modifier switch
+			// above), so every `buttonState == Button1Pressed`-style check below fails whenever a modifier
+			// is held — same class of bug ExtractButtonState fixed on the Unix path (UnixStdinReader.cs).
+			// SetControlKeyStates() re-applies the modifier bits onto the final output further down, so
+			// only the state-machine's recognition needs the stripped value.
+			const MouseFlags modifierMask = MouseFlags.ButtonShift | MouseFlags.ButtonAlt | MouseFlags.ButtonCtrl;
+			var actionState = buttonState & ~modifierMask;
+
 			if (_lastMouseButtonPressed != null
 				&& !_isButtonPressed
 				&& !buttonState.HasFlag(MouseFlags.ReportMousePosition)
@@ -473,10 +348,10 @@ namespace SharpConsoleUI.Helpers
 
 			if ((!_isButtonClicked
 				 && !_isButtonDoubleClicked
-				 && (buttonState == MouseFlags.Button1Pressed
-					 || buttonState == MouseFlags.Button2Pressed
-					 || buttonState == MouseFlags.Button3Pressed
-					 || buttonState == MouseFlags.Button4Pressed)
+				 && (actionState == MouseFlags.Button1Pressed
+					 || actionState == MouseFlags.Button2Pressed
+					 || actionState == MouseFlags.Button3Pressed
+					 || actionState == MouseFlags.Button4Pressed)
 				 && _lastMouseButtonPressed is null)
 				|| (_isButtonPressed && _lastMouseButtonPressed is { } && buttonState.HasFlag(MouseFlags.ReportMousePosition)))
 			{
@@ -504,22 +379,22 @@ namespace SharpConsoleUI.Helpers
 				}
 			}
 			else if (_isButtonDoubleClicked
-					 && (buttonState == MouseFlags.Button1Pressed
-						 || buttonState == MouseFlags.Button2Pressed
-						 || buttonState == MouseFlags.Button3Pressed
-						 || buttonState == MouseFlags.Button4Pressed))
+					 && (actionState == MouseFlags.Button1Pressed
+						 || actionState == MouseFlags.Button2Pressed
+						 || actionState == MouseFlags.Button3Pressed
+						 || actionState == MouseFlags.Button4Pressed))
 			{
-				mouseFlags[0] = GetButtonTripleClicked(buttonState);
+				mouseFlags[0] = GetButtonTripleClicked(actionState);
 				_isButtonDoubleClicked = false;
 				_isButtonTripleClicked = true;
 			}
 			else if (_isButtonClicked
-					 && (buttonState == MouseFlags.Button1Pressed
-						 || buttonState == MouseFlags.Button2Pressed
-						 || buttonState == MouseFlags.Button3Pressed
-						 || buttonState == MouseFlags.Button4Pressed))
+					 && (actionState == MouseFlags.Button1Pressed
+						 || actionState == MouseFlags.Button2Pressed
+						 || actionState == MouseFlags.Button3Pressed
+						 || actionState == MouseFlags.Button4Pressed))
 			{
-				mouseFlags[0] = GetButtonDoubleClicked(buttonState);
+				mouseFlags[0] = GetButtonDoubleClicked(actionState);
 				_isButtonClicked = false;
 				_isButtonDoubleClicked = true;
 
@@ -528,10 +403,10 @@ namespace SharpConsoleUI.Helpers
 
 			else if (!_isButtonClicked
 					 && !_isButtonDoubleClicked
-					 && (buttonState == MouseFlags.Button1Released
-						 || buttonState == MouseFlags.Button2Released
-						 || buttonState == MouseFlags.Button3Released
-						 || buttonState == MouseFlags.Button4Released))
+					 && (actionState == MouseFlags.Button1Released
+						 || actionState == MouseFlags.Button2Released
+						 || actionState == MouseFlags.Button3Released
+						 || actionState == MouseFlags.Button4Released))
 			{
 				mouseFlags[0] = buttonState;
 				_isButtonPressed = false;
@@ -546,7 +421,7 @@ namespace SharpConsoleUI.Helpers
 					var timeSinceLastClick = (DateTime.Now - _lastClickTime).TotalMilliseconds;
 					if (timeSinceLastClick >= 50)
 					{
-						mouseFlags.Add(GetButtonClicked(buttonState));
+						mouseFlags.Add(GetButtonClicked(actionState));
 						_isButtonClicked = true;
 						Task.Run(async () => await ProcessButtonClickedAsync());
 						_lastClickTime = DateTime.Now;
@@ -556,23 +431,23 @@ namespace SharpConsoleUI.Helpers
 				_point = pos;
 
 			}
-			else if (buttonState == MouseFlags.WheeledUp)
+			else if (actionState == MouseFlags.WheeledUp)
 			{
 				mouseFlags[0] = MouseFlags.WheeledUp;
 			}
-			else if (buttonState == MouseFlags.WheeledDown)
+			else if (actionState == MouseFlags.WheeledDown)
 			{
 				mouseFlags[0] = MouseFlags.WheeledDown;
 			}
-			else if (buttonState == MouseFlags.WheeledLeft)
+			else if (actionState == MouseFlags.WheeledLeft)
 			{
 				mouseFlags[0] = MouseFlags.WheeledLeft;
 			}
-			else if (buttonState == MouseFlags.WheeledRight)
+			else if (actionState == MouseFlags.WheeledRight)
 			{
 				mouseFlags[0] = MouseFlags.WheeledRight;
 			}
-			else if (buttonState == MouseFlags.ReportMousePosition)
+			else if (actionState == MouseFlags.ReportMousePosition)
 			{
 				mouseFlags[0] = MouseFlags.ReportMousePosition;
 			}


### PR DESCRIPTION
Adds ExtendOrMoveSelection for Shift+Up/Down range selection anchored like Explorer/Excel, a keyboard Space-toggle path independent of checkbox mode, and a right-click extend-selection when MultiSelectEnabled is set - a mouse alternative to Shift+Click, since terminals often don't deliver Shift/Ctrl click modifiers.

## Summary

Enables keyboard driven multi select using Shift+Up/Down and spacebar.  
Enables mouse based multi select via right mouse click on row to select all rows between current selected row and the right click target row.

## Changes

Keyboard:
Updates the method responsible for handling key presses to also use the current shift press to decide whether to move the selection or extend (only enabled when MultiSelect is enabled).

Mouse:
Adds right click logic to extend the selected range when MultiSelect is enabled.

## Type

- [ ] Bug fix
- [X] New feature
- [X] Enhancement
- [ ] Documentation
- [ ] Refactoring

## Testing

<!-- How did you test these changes? -->
- [ ] Tested with DemoApp
- [X] Tested with relevant example(s) -> custom app which views streaming logs, multi select enabled to export multiple lines to clipboard
- [X] Solution builds without errors
- [ ] All tests pass (`dotnet test SharpConsoleUI.Tests/SharpConsoleUI.Tests.csproj -c Release`)
  - Some tests fail but the same tests fail for me on the master, these tests are not affected by this PR.

## Code quality

<!-- See docs/CODE_QUALITY.md -->
- [X] **No breaking changes** to public API (no removed/renamed members or changed signatures/defaults)
- [X] No console output added to library code
- [X] No magic numbers (literals extracted to `ControlDefaults`/`LayoutDefaults`)
- [X] UI mutations from background threads are marshalled via `EnqueueOnUIThread`/`InvokeAsync`
- [X] New source files carry the file-header banner

## Screenshots

<!-- If applicable, add screenshots for UI changes -->
<img width="1195" height="592" alt="image" src="https://github.com/user-attachments/assets/4c10563f-393f-4db3-a342-f5b05152cb11" />
