### PR TITLE
feat(TableControl): configurable minimum scrollbar thumb size

### DIFF
--- a/SharpConsoleUI/Builders/TableControlBuilder.cs
+++ b/SharpConsoleUI/Builders/TableControlBuilder.cs
@@ -6,6 +6,7 @@
 // License: MIT
 // -----------------------------------------------------------------------
 
+using SharpConsoleUI.Configuration;
 using SharpConsoleUI.Controls;
 using SharpConsoleUI.DataBinding;
 using SharpConsoleUI.Layout;
@@ -49,6 +50,7 @@ public sealed class TableControlBuilder : IControlBuilder<TableControl>
 	private bool _fuzzyFilterEnabled = false;
 	private ScrollbarVisibility _verticalScrollbarVisibility = ScrollbarVisibility.Auto;
 	private ScrollbarVisibility _horizontalScrollbarVisibility = ScrollbarVisibility.Auto;
+	private int _minScrollbarThumbSize = ControlDefaults.DefaultMinScrollbarThumbSize;
 	private ITableDataSource? _dataSource;
 
 	// Event handlers
@@ -652,6 +654,15 @@ public sealed class TableControlBuilder : IControlBuilder<TableControl>
 	}
 
 	/// <summary>
+	/// Sets the minimum vertical scrollbar thumb height, in rows.
+	/// </summary>
+	public TableControlBuilder WithMinScrollbarThumbSize(int size)
+	{
+		_minScrollbarThumbSize = size;
+		return this;
+	}
+
+	/// <summary>
 	/// Sets the virtual data source for lazy loading.
 	/// </summary>
 	public TableControlBuilder WithDataSource(ITableDataSource dataSource)
@@ -743,6 +754,7 @@ public sealed class TableControlBuilder : IControlBuilder<TableControl>
 			FuzzyFilterEnabled = _fuzzyFilterEnabled,
 			VerticalScrollbarVisibility = _verticalScrollbarVisibility,
 			HorizontalScrollbarVisibility = _horizontalScrollbarVisibility,
+			MinScrollbarThumbSize = _minScrollbarThumbSize,
 
 			// Base properties
 			HorizontalAlignment = _horizontalAlignment,

--- a/SharpConsoleUI/Configuration/ControlDefaults.cs
+++ b/SharpConsoleUI/Configuration/ControlDefaults.cs
@@ -70,6 +70,11 @@ namespace SharpConsoleUI.Configuration
 		/// </summary>
 		public const int DefaultPageScrollMultiplier = 5;
 
+		/// <summary>
+		/// Default minimum vertical scrollbar thumb height in rows (default: 1)
+		/// </summary>
+		public const int DefaultMinScrollbarThumbSize = 1;
+
 		// Input defaults
 		/// <summary>
 		/// Debounce delay for rapid input events in milliseconds (default: 300ms)

--- a/SharpConsoleUI/Controls/TableControl/TableControl.Scrolling.cs
+++ b/SharpConsoleUI/Controls/TableControl/TableControl.Scrolling.cs
@@ -101,7 +101,7 @@ public partial class TableControl
 	public int MinScrollbarThumbSize
 	{
 		get => _minScrollbarThumbSize;
-		set { if (_minScrollbarThumbSize == value) return; _minScrollbarThumbSize = value; Invalidate(Invalidation.Repaint); }
+		set { if (_minScrollbarThumbSize == value) return; _minScrollbarThumbSize = value; OnPropertyChanged(); Invalidate(Invalidation.Repaint); }
 	}
 
 	#endregion

--- a/SharpConsoleUI/Controls/TableControl/TableControl.Scrolling.cs
+++ b/SharpConsoleUI/Controls/TableControl/TableControl.Scrolling.cs
@@ -95,6 +95,15 @@ public partial class TableControl
 		set { _horizontalScrollbarVisibility = value; OnPropertyChanged(); Invalidate(Invalidation.Relayout); }
 	}
 
+	/// <summary>
+	/// Gets or sets the minimum vertical scrollbar thumb height, in rows.
+	/// </summary>
+	public int MinScrollbarThumbSize
+	{
+		get => _minScrollbarThumbSize;
+		set { if (_minScrollbarThumbSize == value) return; _minScrollbarThumbSize = value; Invalidate(Invalidation.Repaint); }
+	}
+
 	#endregion
 
 	#region Scroll State
@@ -235,7 +244,8 @@ public partial class TableControl
 		if (thumbTrackHeight <= 0) return (trackTop, trackHeight, 0, trackHeight);
 
 		double viewportRatio = (double)visibleRows / totalRows;
-		int thumbHeight = Math.Clamp((int)(thumbTrackHeight * viewportRatio), 1, thumbTrackHeight);
+		int minThumbHeight = Math.Min(_minScrollbarThumbSize, thumbTrackHeight);
+		int thumbHeight = Math.Clamp((int)(thumbTrackHeight * viewportRatio), minThumbHeight, thumbTrackHeight);
 		double scrollRatio = (double)_scrollOffset / Math.Max(1, totalRows - visibleRows);
 		int thumbY = arrowSlots > 0 ? 1 : 0; // start after top arrow
 		int maxThumbPos = thumbTrackHeight - thumbHeight;

--- a/SharpConsoleUI/Controls/TableControl/TableControl.cs
+++ b/SharpConsoleUI/Controls/TableControl/TableControl.cs
@@ -139,6 +139,7 @@ public partial class TableControl : BaseControl, IInteractiveControl, IFocusable
 	private int _horizontalScrollOffset = 0;
 	private ScrollbarVisibility _verticalScrollbarVisibility = ScrollbarVisibility.Auto;
 	private ScrollbarVisibility _horizontalScrollbarVisibility = ScrollbarVisibility.Auto;
+	private int _minScrollbarThumbSize = ControlDefaults.DefaultMinScrollbarThumbSize;
 
 	// Mouse gesture capture: a fresh Button1 press captures one sub-region; every subsequent resent
 	// press/drag routes to it without re-hit-testing (SGR re-sends Button1Pressed on motion). Replaces


### PR DESCRIPTION
Adds TableControl.MinScrollbarThumbSize (default 1 row, via new ControlDefaults.DefaultMinScrollbarThumbSize constant) to floor the vertical scrollbar thumb height, plus a builder WithMinScrollbarThumbSize method to set it.

## Summary

Allows setting a min scroll bar thumb size making it easier to grab when the table has thousands of rows.

## Changes

Adds control default DefaultMinScrollbarThumbSize set to 1 (matches current behavior).  
Adds new TableControl property MinScrollbarThumbSize.

## Type

- [ ] Bug fix
- [X] New feature
- [X] Enhancement
- [ ] Documentation
- [ ] Refactoring

## Testing

<!-- How did you test these changes? -->
- [ ] Tested with DemoApp
- [X] Tested with relevant example(s) -> custom app that has hundreds of thousands of items in a table
- [X] Solution builds without errors
- [ ] All tests pass (`dotnet test SharpConsoleUI.Tests/SharpConsoleUI.Tests.csproj -c Release`)
  - Some tests fail but the same tests fail for me on the master, these tests are not affected by this PR.

## Code quality

<!-- See docs/CODE_QUALITY.md -->
- [X] **No breaking changes** to public API (no removed/renamed members or changed signatures/defaults)
- [X] No console output added to library code
- [X] No magic numbers (literals extracted to `ControlDefaults`/`LayoutDefaults`)
- [X] UI mutations from background threads are marshalled via `EnqueueOnUIThread`/`InvokeAsync`
- [X] New source files carry the file-header banner

## Screenshots

<!-- If applicable, add screenshots for UI changes -->
31k rows - scroll bar size is still 3:
<img width="1203" height="633" alt="image" src="https://github.com/user-attachments/assets/ccf60c56-3de9-4b0f-ac29-3ac56ce8694c" />

