### PR TITLE
feat(TableControl): minimum auto-width floor per column

### DIFF
--- a/SharpConsoleUI/Builders/TableControlBuilder.cs
+++ b/SharpConsoleUI/Builders/TableControlBuilder.cs
@@ -119,6 +119,15 @@ public sealed class TableControlBuilder : IControlBuilder<TableControl>
 	}
 
 	/// <summary>
+	/// Adds a column with a minimum auto-width floor. See <see cref="TableColumn.MinWidth"/>.
+	/// </summary>
+	public TableControlBuilder AddColumn(string header, TextJustification alignment, int? width, int? minWidth)
+	{
+		_columns.Add(new TableColumn(header, alignment, width) { MinWidth = minWidth });
+		return this;
+	}
+
+	/// <summary>
 	/// Adds multiple columns from header names.
 	/// </summary>
 	public TableControlBuilder WithColumns(params string[] headers)

--- a/SharpConsoleUI/Controls/TableControl/ITableDataSource.cs
+++ b/SharpConsoleUI/Controls/TableControl/ITableDataSource.cs
@@ -75,6 +75,15 @@ public interface ITableDataSource : INotifyCollectionChanged
 	int? GetColumnWidth(int columnIndex) => null;
 
 	/// <summary>
+	/// Gets a minimum width floor for a column when it is auto-width and gets shrunk to fit the
+	/// available space. Null means no floor (the column can be shrunk down to 1 character). Ignored
+	/// for columns with a fixed <see cref="GetColumnWidth"/>. When honoring this floor would require
+	/// more space than is available, the table instead lets its total content width exceed the
+	/// viewport so a horizontal scrollbar can be used to pan to it.
+	/// </summary>
+	int? GetColumnMinWidth(int columnIndex) => null;
+
+	/// <summary>
 	/// Gets the background color for a row. Null means use table default.
 	/// </summary>
 	Color? GetRowBackgroundColor(int rowIndex) => null;

--- a/SharpConsoleUI/Controls/TableControl/TableColumn.cs
+++ b/SharpConsoleUI/Controls/TableControl/TableColumn.cs
@@ -54,6 +54,21 @@ public class TableColumn
 		set { if (_width == value) return; _width = value; Owner?.OnColumnDisplayChanged(this, true, Invalidation.Relayout); }
 	}
 
+	private int? _minWidth;
+
+	/// <summary>
+	/// Gets or sets a minimum width floor applied when this column is auto-width and gets shrunk to
+	/// fit the available space. Ignored for columns with a fixed <see cref="Width"/>. Null means no
+	/// floor (the column can be shrunk down to 1 character, the previous fixed behavior). When the
+	/// column's natural content would still be shrunk below this floor, the table instead allows its
+	/// total content width to exceed the viewport so a horizontal scrollbar can be used to pan to it.
+	/// </summary>
+	public int? MinWidth
+	{
+		get => _minWidth;
+		set { if (_minWidth == value) return; _minWidth = value; Owner?.OnColumnDisplayChanged(this, true, Invalidation.Relayout); }
+	}
+
 	private bool _noWrap = false;
 
 	/// <summary>

--- a/SharpConsoleUI/Controls/TableControl/TableControl.Rendering.cs
+++ b/SharpConsoleUI/Controls/TableControl/TableControl.Rendering.cs
@@ -151,6 +151,36 @@ public partial class TableControl
 		int writeX = x;
 		int maxX = viewportWidth == int.MaxValue ? int.MaxValue : x + viewportWidth;
 
+		// Logical position along the row's full (unscrolled) content stream, counted from just after
+		// the left border. Mirrors DrawHorizontalLine's colOffset/charPos scheme so inter-column
+		// separators pan together with cell content; only characters at or past hScrollOffset are
+		// actually written (and advance writeX) - earlier ones are skipped, shifting the visible
+		// window left. The outer left/right border chars are intentionally NOT gated by this (kept
+		// fixed), matching DrawHorizontalLine's treatment of its own border chars.
+		int logicalPos = 0;
+
+		void DrawChar(char ch, Color fg, Color bg)
+		{
+			if (logicalPos >= hScrollOffset)
+			{
+				if (writeX >= clipRect.X && writeX < clipRect.Right && writeX < maxX)
+					buffer.SetNarrowCell(writeX, y, ch, fg, bg);
+				writeX++;
+			}
+			logicalPos++;
+		}
+
+		void DrawFullCell(Cell cell)
+		{
+			if (logicalPos >= hScrollOffset)
+			{
+				if (writeX >= clipRect.X && writeX < clipRect.Right && writeX < maxX)
+					buffer.SetCell(writeX, y, cell);
+				writeX++;
+			}
+			logicalPos++;
+		}
+
 		if (hasBorder)
 		{
 			if (writeX >= clipRect.X && writeX < clipRect.Right && writeX < maxX)
@@ -165,6 +195,7 @@ public partial class TableControl
 		{
 			int colW = colWidths[c];
 			string cellText = c < cells.Count ? cells[c] : string.Empty;
+			bool isLastColumn = c == colWidths.Length - 1;
 
 			TextJustification align = TextJustification.Left;
 			if (cols != null && c < cols.Count)
@@ -186,6 +217,8 @@ public partial class TableControl
 				cellFg = selectedCellFg ?? rowFg;
 			}
 
+			int cellLogicalStart = logicalPos;
+
 			if (isEditCell)
 			{
 				// Render edit buffer as plain text with cursor using Unicode-aware width
@@ -193,48 +226,41 @@ public partial class TableControl
 				int visLen = editCells.Count;
 				int cursorPos = editCursorPos;
 
-				// Fill entire cell with edit background first
-				int cellStartX = writeX;
 				for (int i = 0; i < colW; i++)
 				{
-					int cx = cellStartX + i;
-					if (cx >= clipRect.X && cx < clipRect.Right && cx < maxX)
+					Color fg = cellFg;
+					Color bg = cellBg;
+					// Draw cursor with inverted colors
+					if (i == cursorPos)
 					{
-						Color fg = cellFg;
-						Color bg = cellBg;
-						// Draw cursor with inverted colors
-						if (i == cursorPos)
+						fg = Color.White;
+						bg = Color.Black;
+					}
+					if (i < visLen)
+					{
+						var srcCell = editCells[i];
+						// If this is a wide base char at the last column position,
+						// replace with space to avoid rendering half a glyph
+						if (i == colW - 1 && !srcCell.IsWideContinuation
+							&& Helpers.UnicodeWidth.IsWideRune(srcCell.Character))
 						{
-							fg = Color.White;
-							bg = Color.Black;
-						}
-						if (i < visLen)
-						{
-							var srcCell = editCells[i];
-							// If this is a wide base char at the last column position,
-							// replace with space to avoid rendering half a glyph
-							if (i == colW - 1 && !srcCell.IsWideContinuation
-								&& Helpers.UnicodeWidth.IsWideRune(srcCell.Character))
-							{
-								buffer.SetNarrowCell(cx, y, ' ', fg, bg);
-							}
-							else
-							{
-								var editCell = new Cell(srcCell.Character, fg, bg, srcCell.Decorations)
-								{
-									IsWideContinuation = srcCell.IsWideContinuation,
-									Combiners = srcCell.Combiners
-								};
-								buffer.SetCell(cx, y, editCell);
-							}
+							DrawChar(' ', fg, bg);
 						}
 						else
 						{
-							buffer.SetNarrowCell(cx, y, ' ', fg, bg);
+							var editCell = new Cell(srcCell.Character, fg, bg, srcCell.Decorations)
+							{
+								IsWideContinuation = srcCell.IsWideContinuation,
+								Combiners = srcCell.Combiners
+							};
+							DrawFullCell(editCell);
 						}
 					}
+					else
+					{
+						DrawChar(' ', fg, bg);
+					}
 				}
-				writeX += colW;
 			}
 			else
 			{
@@ -284,12 +310,7 @@ public partial class TableControl
 				// Left padding
 				for (int i = 0; i < padLeft; i++)
 				{
-					if (writeX >= clipRect.X && writeX < clipRect.Right && writeX < maxX)
-					{
-						Color bg = cellBg;
-						buffer.SetNarrowCell(writeX, y, ' ', cellFg, bg);
-					}
-					writeX++;
+					DrawChar(' ', cellFg, cellBg);
 				}
 
 				// Cell content - build match ranges for this column
@@ -311,31 +332,29 @@ public partial class TableControl
 				int charIdx = 0;
 				foreach (var cell in cellCells)
 				{
-					if (writeX >= clipRect.X && writeX < clipRect.Right && writeX < maxX)
+					// Override background for selected/hovered rows
+					Color bg = isSelected ? cellBg : cell.Background;
+					Color fg = isSelected ? cellFg : cell.Foreground;
+
+					// Apply filter match highlight
+					if (highlightIndices != null && highlightIndices.Contains(charIdx))
 					{
-						// Override background for selected/hovered rows
-						Color bg = isSelected ? cellBg : cell.Background;
-						Color fg = isSelected ? cellFg : cell.Foreground;
-
-						// Apply filter match highlight
-						if (highlightIndices != null && highlightIndices.Contains(charIdx))
-						{
-							bg = Color.DarkYellow;
-						}
-
-						var bufCell = new Cell(cell.Character, fg, bg, cell.Decorations)
-						{
-							IsWideContinuation = cell.IsWideContinuation,
-							Combiners = cell.Combiners
-						};
-						buffer.SetCell(writeX, y, bufCell);
+						bg = Color.DarkYellow;
 					}
-					writeX++;
+
+					var bufCell = new Cell(cell.Character, fg, bg, cell.Decorations)
+					{
+						IsWideContinuation = cell.IsWideContinuation,
+						Combiners = cell.Combiners
+					};
+					DrawFullCell(bufCell);
 					charIdx++;
 				}
 
-				// Apply truncation fade if enabled and this cell was truncated
-				if (_truncationFade && wasTruncated && colW > 4)
+				// Apply truncation fade if enabled and this cell was truncated. Skipped when the scroll
+				// offset cuts into the middle of this same cell (cellStartX/colW would no longer bound
+				// its actually-drawn span in the buffer, which could bleed the fade into the next column).
+				if (_truncationFade && wasTruncated && colW > 4 && cellLogicalStart >= hScrollOffset)
 				{
 					float[] fadeSteps = { 0.10f, 0.35f, 0.65f, 0.90f };
 					int fadeStart = cellStartX + colW - 4;
@@ -354,24 +373,27 @@ public partial class TableControl
 				// Right padding
 				for (int i = 0; i < padRight; i++)
 				{
-					if (writeX >= clipRect.X && writeX < clipRect.Right && writeX < maxX)
-					{
-						Color bg = cellBg;
-						buffer.SetNarrowCell(writeX, y, ' ', cellFg, bg);
-					}
-					writeX++;
+					DrawChar(' ', cellFg, cellBg);
 				}
 			}
 
-			// Column separator
+			// Column separator / right border. The final column's trailing border char is the table's
+			// right edge and, like the left border, stays fixed rather than panning with scroll.
 			if (hasBorder)
 			{
-				if (writeX >= clipRect.X && writeX < clipRect.Right && writeX < maxX)
+				if (isLastColumn)
 				{
-					Color bg = borderBg;
-					buffer.SetNarrowCell(writeX, y, box.Vertical, borderColor, bg);
+					if (writeX >= clipRect.X && writeX < clipRect.Right && writeX < maxX)
+					{
+						Color bg = borderBg;
+						buffer.SetNarrowCell(writeX, y, box.Vertical, borderColor, bg);
+					}
+					writeX++;
 				}
-				writeX++;
+				else
+				{
+					DrawChar(box.Vertical, borderColor, borderBg);
+				}
 			}
 			else if (_columnSeparator.HasValue && c < colWidths.Length - 1
 				&& !(_checkboxMode && c == 0))
@@ -381,20 +403,12 @@ public partial class TableControl
 				// flush separators are just the glyph. SeparatorWidth keeps the width budget in sync.
 				if (_columnSeparatorPadded)
 				{
-					if (writeX >= clipRect.X && writeX < clipRect.Right && writeX < maxX)
-						buffer.SetNarrowCell(writeX, y, ' ', cellFg, rowBg);
-					writeX++;
+					DrawChar(' ', cellFg, rowBg);
 				}
-				if (writeX >= clipRect.X && writeX < clipRect.Right && writeX < maxX)
-				{
-					buffer.SetNarrowCell(writeX, y, _columnSeparator.Value, sepColor, rowBg);
-				}
-				writeX++;
+				DrawChar(_columnSeparator.Value, sepColor, rowBg);
 				if (_columnSeparatorPadded)
 				{
-					if (writeX >= clipRect.X && writeX < clipRect.Right && writeX < maxX)
-						buffer.SetNarrowCell(writeX, y, ' ', cellFg, rowBg);
-					writeX++;
+					DrawChar(' ', cellFg, rowBg);
 				}
 			}
 		}
@@ -671,6 +685,12 @@ public partial class TableControl
 		int totalColumnsWidth = GetTotalColumnsWidth(colWidths);
 		bool showHScrollbar = ShouldShowHorizontalScrollbar(totalColumnsWidth, contentWidth);
 
+		// Clamp locally rather than mutating _horizontalScrollOffset here - the field is authoritatively
+		// clamped by the mouse drag/wheel handlers; this just guards against a stale offset from before
+		// a resize/data change made the content narrower than it used to be.
+		int maxHScroll = Math.Max(0, totalColumnsWidth - contentWidth);
+		int effectiveHScroll = Math.Min(_horizontalScrollOffset, maxHScroll);
+
 		int startX = bounds.X + Margin.Left;
 		int currentY = bounds.Y + Margin.Top;
 		int maxY = bounds.Bottom - Margin.Bottom;
@@ -718,7 +738,7 @@ public partial class TableControl
 		{
 			FillSideMargins(currentY);
 			DrawHorizontalLine(buffer, startX, currentY, colWidths, clipRect, box, borderColor, effectiveBg,
-				box.TopLeft, box.TopTee, box.TopRight, box.Horizontal);
+				box.TopLeft, box.TopTee, box.TopRight, box.Horizontal, hScrollOffset: effectiveHScroll);
 			currentY++;
 		}
 
@@ -761,7 +781,8 @@ public partial class TableControl
 				headerCells.Insert(0, "");
 
 			DrawDataRow(buffer, startX, currentY, colWidths, clipRect, box, borderColor, effectiveBg,
-				headerCells, renderCols, headerFg, headerBg, hasBorder, trailingFillWidth: scrollbarGutter);
+				headerCells, renderCols, headerFg, headerBg, hasBorder,
+				hScrollOffset: effectiveHScroll, trailingFillWidth: scrollbarGutter);
 
 			// Update column rendered positions for hit testing — skip checkbox column
 			{
@@ -793,7 +814,7 @@ public partial class TableControl
 			{
 				FillSideMargins(currentY);
 				DrawHorizontalLine(buffer, startX, currentY, colWidths, clipRect, box, borderColor, effectiveBg,
-					box.LeftTee, box.Cross, box.RightTee, box.Horizontal);
+					box.LeftTee, box.Cross, box.RightTee, box.Horizontal, hScrollOffset: effectiveHScroll);
 				currentY++;
 			}
 		}
@@ -818,7 +839,7 @@ public partial class TableControl
 			{
 				FillSideMargins(currentY);
 				DrawHorizontalLine(buffer, startX, currentY, colWidths, clipRect, box, borderColor, effectiveBg,
-					box.LeftTee, box.Cross, box.RightTee, box.Horizontal);
+					box.LeftTee, box.Cross, box.RightTee, box.Horizontal, hScrollOffset: effectiveHScroll);
 				currentY++;
 			}
 
@@ -939,6 +960,7 @@ public partial class TableControl
 			FillSideMargins(currentY);
 			DrawDataRow(buffer, startX, currentY, colWidths, clipRect, box, borderColor, effectiveBg,
 				rowCells, renderCols, effectiveRowFg, effectiveRowBg, hasBorder,
+				hScrollOffset: effectiveHScroll,
 				isSelected: isRowSel || isHovered,
 				selectedCellIndex: selectedCell, selectedCellBg: cellHighlightBg, selectedCellFg: cellHighlightFg,
 				editCellIndex: editCellIndex, editCursorPos: editCursorPos,
@@ -966,7 +988,8 @@ public partial class TableControl
 		{
 			FillSideMargins(currentY);
 			DrawDataRow(buffer, startX, currentY, colWidths, clipRect, box, borderColor, effectiveBg,
-				new List<string>(), renderCols, fgColor, bgColor, hasBorder, trailingFillWidth: scrollbarGutter);
+				new List<string>(), renderCols, fgColor, bgColor, hasBorder,
+				hScrollOffset: effectiveHScroll, trailingFillWidth: scrollbarGutter);
 			currentY++;
 		}
 
@@ -1009,7 +1032,7 @@ public partial class TableControl
 			// Standard bottom border with column tees
 			FillSideMargins(currentY);
 			DrawHorizontalLine(buffer, startX, currentY, colWidths, clipRect, box, borderColor, effectiveBg,
-				box.BottomLeft, box.BottomTee, box.BottomRight, box.Horizontal);
+				box.BottomLeft, box.BottomTee, box.BottomRight, box.Horizontal, hScrollOffset: effectiveHScroll);
 			currentY++;
 		}
 

--- a/SharpConsoleUI/Controls/TableControl/TableControl.cs
+++ b/SharpConsoleUI/Controls/TableControl/TableControl.cs
@@ -1196,24 +1196,33 @@ public partial class TableControl : BaseControl, IInteractiveControl, IFocusable
 				for (int c = 0; c < colCount; c++)
 				{
 					if (cols[c].Width.HasValue) continue;
-					widths[c] = Math.Max(1, (int)(widths[c] * ratio));
+					int minW = Math.Max(1, cols[c].MinWidth ?? 1);
+					widths[c] = Math.Max(minW, (int)(widths[c] * ratio));
 					assigned += widths[c];
 					lastAutoCol = c;
 				}
 				if (lastAutoCol >= 0)
-					widths[lastAutoCol] = Math.Max(1, widths[lastAutoCol] + (contentWidth - assigned));
+				{
+					int minWLast = Math.Max(1, cols[lastAutoCol].MinWidth ?? 1);
+					widths[lastAutoCol] = Math.Max(minWLast, widths[lastAutoCol] + (contentWidth - assigned));
+				}
 			}
 			else
 			{
-				// Not enough space even for fixed columns — shrink everything
+				// Not enough space even for fixed columns — shrink everything. Fixed-width columns have
+				// no MinWidth concept (floor stays 1); auto columns respect their configured floor, which
+				// may leave the total width exceeding contentWidth - the table then relies on horizontal
+				// scrolling rather than crushing an auto column below its usable floor.
 				double ratio = (double)contentWidth / totalNatural;
 				int assigned = 0;
 				for (int c = 0; c < colCount - 1; c++)
 				{
-					widths[c] = Math.Max(1, (int)(widths[c] * ratio));
+					int minW = cols[c].Width.HasValue ? 1 : Math.Max(1, cols[c].MinWidth ?? 1);
+					widths[c] = Math.Max(minW, (int)(widths[c] * ratio));
 					assigned += widths[c];
 				}
-				widths[colCount - 1] = Math.Max(1, contentWidth - assigned);
+				int minWLast = cols[colCount - 1].Width.HasValue ? 1 : Math.Max(1, cols[colCount - 1].MinWidth ?? 1);
+				widths[colCount - 1] = Math.Max(minWLast, contentWidth - assigned);
 			}
 		}
 
@@ -1314,24 +1323,35 @@ public partial class TableControl : BaseControl, IInteractiveControl, IFocusable
 				{
 					bool isFixed = _columnWidthOverrides.ContainsKey(c) || _dataSource.GetColumnWidth(c).HasValue;
 					if (isFixed) continue;
-					widths[c] = Math.Max(1, (int)(widths[c] * ratio));
+					int minW = Math.Max(1, _dataSource.GetColumnMinWidth(c) ?? 1);
+					widths[c] = Math.Max(minW, (int)(widths[c] * ratio));
 					assigned += widths[c];
 					lastAutoCol = c;
 				}
 				if (lastAutoCol >= 0)
-					widths[lastAutoCol] = Math.Max(1, widths[lastAutoCol] + (contentWidth - assigned));
+				{
+					int minWLast = Math.Max(1, _dataSource.GetColumnMinWidth(lastAutoCol) ?? 1);
+					widths[lastAutoCol] = Math.Max(minWLast, widths[lastAutoCol] + (contentWidth - assigned));
+				}
 			}
 			else
 			{
-				// Not enough space even for fixed columns — shrink everything
+				// Not enough space even for fixed columns — shrink everything. Fixed/overridden columns
+				// have no MinWidth concept (floor stays 1); auto columns respect their configured floor,
+				// which may leave the total width exceeding contentWidth - the table then relies on
+				// horizontal scrolling rather than crushing an auto column below its usable floor.
 				double ratio = (double)contentWidth / totalNatural;
 				int assigned = 0;
 				for (int c = 0; c < colCount - 1; c++)
 				{
-					widths[c] = Math.Max(1, (int)(widths[c] * ratio));
+					bool isFixed = _columnWidthOverrides.ContainsKey(c) || _dataSource.GetColumnWidth(c).HasValue;
+					int minW = isFixed ? 1 : Math.Max(1, _dataSource.GetColumnMinWidth(c) ?? 1);
+					widths[c] = Math.Max(minW, (int)(widths[c] * ratio));
 					assigned += widths[c];
 				}
-				widths[colCount - 1] = Math.Max(1, contentWidth - assigned);
+				bool isLastFixed = _columnWidthOverrides.ContainsKey(colCount - 1) || _dataSource.GetColumnWidth(colCount - 1).HasValue;
+				int minWLast = isLastFixed ? 1 : Math.Max(1, _dataSource.GetColumnMinWidth(colCount - 1) ?? 1);
+				widths[colCount - 1] = Math.Max(minWLast, contentWidth - assigned);
 			}
 		}
 


### PR DESCRIPTION
Adds TableColumn.MinWidth (and ITableDataSource.GetColumnMinWidth for virtual data sources): a floor applied when an auto-width column would otherwise be shrunk to fit the viewport. When honoring every column's floor would exceed the viewport, the table now allows total content width to exceed it so a horizontal scrollbar can pan to the overflow, instead of crushing a column below its usable width. Also adds a builder AddColumn overload that sets it.

## Summary

This allows columns to avoid being squeezed down to nothing by other columns that have very wide content.

## Changes

Allows columns to specify a MinWidth instead of just a fixed Width.  Adjustments needed for horizontal scroll to work correctly.

## Type

- [ ] Bug fix
- [X] New feature
- [X] Enhancement
- [ ] Documentation
- [ ] Refactoring

## Testing

<!-- How did you test these changes? -->
- [ ] Tested with DemoApp
- [X] Tested with relevant example(s) -> custom app tested, vastly improved behavior when a single column has very long content
- [X] Solution builds without errors
- [ ] All tests pass (`dotnet test SharpConsoleUI.Tests/SharpConsoleUI.Tests.csproj -c Release`)
  - Some fail on my setup in both master and this branch, this PR does not cause additional failures.
 
## Code quality

<!-- See docs/CODE_QUALITY.md -->
- [X] **No breaking changes** to public API (no removed/renamed members or changed signatures/defaults)
- [X] No console output added to library code
- [X] No magic numbers (literals extracted to `ControlDefaults`/`LayoutDefaults`)
- [X] UI mutations from background threads are marshalled via `EnqueueOnUIThread`/`InvokeAsync`
- [X] New source files carry the file-header banner
